### PR TITLE
add Zeex's amx_assembly repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "amx"]
+	path = amx
+	url = https://github.com/Zeex/amx_assembly


### PR DESCRIPTION
That submodule got lost somehow in some commit.
