### PR TITLE
Loads of fixes and improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+/a_actor.inc
+/a_http.inc
+/a_npc.inc
+/a_objects.inc
+/a_players.inc
+/a_samp.inc
+/a_sampdb.inc
+/a_vehicles.inc
+/amx_assembly
+/core.inc
+/datagram.inc
+/file.inc
+/float.inc
+/string.inc
+/time.inc
+/y_inline_3.inc

--- a/YSI_Coding/y_hooks.inc
+++ b/YSI_Coding/y_hooks.inc
@@ -90,7 +90,7 @@ Changelog:
 
 #include "..\YSI_Internal\y_cgen"
 
-#include "..\amx\asm"
+#include "..\YSI_Internal\amx_assembly"
 //asm"
 
 #include "y_hooks/impl"

--- a/YSI_Coding/y_inline.inc
+++ b/YSI_Coding/y_inline.inc
@@ -75,9 +75,7 @@ Changelog:
 #endif
 
 
-#include "..\amx\asm"
-#include "..\amx\disasm"
-#include "..\amx\frame_info"
+#include "..\YSI_Internal\amx_assembly"
 #include "..\YSI_Storage\y_amx"
 #include "..\YSI_Internal\y_shortfunc"
 #include "..\YSI_Core\y_debug"
@@ -92,8 +90,6 @@ Changelog:
 #include "y_inline/impl"
 
 #if defined YSI_TESTS
-	#include "..\amx\amx_memory.inc"
-	
 	#include "..\YSI_Core\y_testing"
 	#include "y_hooks"
 	#include "y_inline/tests"

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -174,8 +174,9 @@ Operators:
     #define DYNAMIC_MEMORY (65536)
 #endif
 #pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
+
 // Disable future "#pragma dynamic XXX" by breaking them (will error).
-#define dynamic dynamic_
+#define dynamic __dynamic
 
 // Sort of "module local" variables.
 stock

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -138,23 +138,33 @@ Operators:
 
 #include "..\YSI_Internal\amx_assembly"
 
-#define MALLOC_KB_TO_CELL ((1024 * 8) / cellbits)
+#define GB_TO_MB(%0) ((%0) * 1024)
+
+#define MB_TO_KB(%0) ((%0) * 1024)
+#define GB_TO_KB(%0) ((%0) * 1024 * 1024)
+
+#define KB_TO_BYTE(%0) ((%0) * 1024)
+#define MB_TO_BYTE(%0) ((%0) * 1024 * 1024)
+#define GB_TO_BYTE(%0) ((%0) * 1024 * 1024 * 1024)
+
+#define BYTE_TO_CELL(%0) ((%0) * 8 / cellbits)
+#define KB_TO_CELL(%0)   BYTE_TO_CELL(KB_TO_BYTE(%0))
+#define MB_TO_CELL(%0)   BYTE_TO_CELL(MB_TO_BYTE(%0))
+#define GB_TO_CELL(%0)   BYTE_TO_CELL(GB_TO_BYTE(%0))
 
 #define NO_ALLOC (Alloc:0)
 
 #if !defined MALLOC_MEMORY
-	#if defined MALLOC_MEMORY_KB
-		#define MALLOC_MEMORY ((MALLOC_MEMORY_KB) * MALLOC_KB_TO_CELL)
+	#if defined MALLOC_MEMORY_GB
+		#define MALLOC_MEMORY GB_TO_CELL(MALLOC_MEMORY_GB)
+	#elseif defined MALLOC_MEMORY_MB
+		#define MALLOC_MEMORY MB_TO_CELL(MALLOC_MEMORY_MB)
+	#elseif defined MALLOC_MEMORY_KB
+		#define MALLOC_MEMORY KB_TO_CELL(MALLOC_MEMORY_KB)
+	#elseif defined MALLOC_MEMORY_B
+		#define MALLOC_MEMORY BYTE_TO_CELL(MALLOC_MEMORY_B)
 	#else
-		#if defined MALLOC_MEMORY_MB
-			#define MALLOC_MEMORY ((MALLOC_MEMORY_MB) * 1024 * MALLOC_KB_TO_CELL)
-		#else
-			#if defined MALLOC_MEMORY_B
-				#define MALLOC_MEMORY (((MALLOC_MEMORY_B) * 8) / cellbits)
-			#else
-				#define MALLOC_MEMORY (16 * 1024 * MALLOC_KB_TO_CELL)
-			#endif
-		#endif
+		#define MALLOC_MEMORY MB_TO_CELL(16)
 	#endif
 #endif
 

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -175,8 +175,38 @@ Operators:
 #endif
 #pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
 
-// Disable future "#pragma dynamic XXX" by breaking them (will error).
-#define dynamic __dynamic
+// ========================================================================== //
+//                                                                            //
+//                                 IMPORTANT!                                 //
+//                                                                            //
+// ========================================================================== //
+#define dynamic dynamic_is_now_DYNAMIC_MEMORY_                                //
+// ========================================================================== //
+//                                                                            //
+// dynamic_is_now_DYNAMIC_MEMORY_                                             //
+//                                                                            //
+// If you get a warning or error about "dynamic_is_now_DYNAMIC_MEMORY_",      //
+// hopefully (though doubtfully) you searched for something related to it and //
+// found this.  If you are slightly confused, just remember that any          //
+// reference to that variable is actually a reference to a variable called    //
+// "dynamic", and so the error/warning refers to that.                        //
+//                                                                            //
+// _is_now_DYNAMIC_MEMORY_                                                    //
+//                                                                            //
+// If you get an error or warning about "_is_now_DYNAMIC_MEMORY_", it is      //
+// because you have tried to use "#pragma dynamic <number>" after including   //
+// "y_malloc" (or another library that eventually includes "y_malloc").       //
+// Because that library allocates memory from the heap, it needs control over //
+// how much memory is in the heap to begin with.  You do this with            //
+// "#pragma dynamic <number>", which that library does.  Because using that a //
+// second time somewhere in your mode will break "y_malloc", it disables the  //
+// pragma, and instead outputs that error.  If you need to increase your      //
+// stack or heap size (due to a stack/heap collision), add this to the very   //
+// top of your mode:                                                          //
+//                                                                            //
+//   #define DYNAMIC_MEMORY <number>                                          //
+//                                                                            //
+// ========================================================================== //
 
 // Sort of "module local" variables.
 stock

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -174,6 +174,8 @@ Operators:
     #define DYNAMIC_MEMORY (65536)
 #endif
 #pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
+// Disable future "#pragma dynamic XXX" by breaking them (will error).
+#define dynamic dynamic_
 
 // Sort of "module local" variables.
 stock

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -168,45 +168,52 @@ Operators:
 	#endif
 #endif
 
-// Allocate extra memory for the normal stack and heap (64k, 16 times the size
-// of the default stack)!
-#if !defined DYNAMIC_MEMORY
-    #define DYNAMIC_MEMORY (65536)
+#if defined YSI_NO_HEAP_MALLOC
+	#if defined DYNAMIC_MEMORY
+		#pragma dynamic DYNAMIC_MEMORY
+		#define dynamic dynamic_is_now_DYNAMIC_MEMORY_ // See below...
+	#endif
+#else
+	// Allocate extra memory for the normal stack and heap (64k, 16 times the
+	// size of the default stack)!
+	#if !defined DYNAMIC_MEMORY
+		#define DYNAMIC_MEMORY (65536)
+	#endif
+	#pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
+	
+	// ====================================================================== //
+	//                                                                        //
+	//                                 IMPORTANT!                             //
+	//                                                                        //
+	// ====================================================================== //
+	#define dynamic dynamic_is_now_DYNAMIC_MEMORY_                            //
+	// ====================================================================== //
+	//                                                                        //
+	// dynamic_is_now_DYNAMIC_MEMORY_                                         //
+	//                                                                        //
+	// If you get a warning or error about "dynamic_is_now_DYNAMIC_MEMORY_",  //
+	// hopefully (though doubtfully) you searched for something related to it //
+	// and found this.  If you are slightly confused, just remember that any  //
+	// reference to that variable is actually a reference to a variable       //
+	// called "dynamic", and so the error/warning refers to that.             //
+	//                                                                        //
+	// _is_now_DYNAMIC_MEMORY_                                                //
+	//                                                                        //
+	// If you get an error or warning about "_is_now_DYNAMIC_MEMORY_", it is  //
+	// because you have tried to use "#pragma dynamic <number>" after         //
+	// including "y_malloc" (or another library that eventually includes      //
+	// "y_malloc").  Because that library allocates memory from the heap, it  //
+	// needs control over how much memory is in the heap to begin with.  You  //
+	// do this with "#pragma dynamic <number>", which that library does.      //
+	// Because using that a second time somewhere in your mode will break     //
+	// "y_malloc", it disables the pragma, and instead outputs that error.    //
+	// If you need to increase your stack or heap size (due to a stack/heap   //
+	// collision), add this to the very top of your mode:                     //
+	//                                                                        //
+	//   #define DYNAMIC_MEMORY <number>                                      //
+	//                                                                        //
+	// ====================================================================== //
 #endif
-#pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
-
-// ========================================================================== //
-//                                                                            //
-//                                 IMPORTANT!                                 //
-//                                                                            //
-// ========================================================================== //
-#define dynamic dynamic_is_now_DYNAMIC_MEMORY_                                //
-// ========================================================================== //
-//                                                                            //
-// dynamic_is_now_DYNAMIC_MEMORY_                                             //
-//                                                                            //
-// If you get a warning or error about "dynamic_is_now_DYNAMIC_MEMORY_",      //
-// hopefully (though doubtfully) you searched for something related to it and //
-// found this.  If you are slightly confused, just remember that any          //
-// reference to that variable is actually a reference to a variable called    //
-// "dynamic", and so the error/warning refers to that.                        //
-//                                                                            //
-// _is_now_DYNAMIC_MEMORY_                                                    //
-//                                                                            //
-// If you get an error or warning about "_is_now_DYNAMIC_MEMORY_", it is      //
-// because you have tried to use "#pragma dynamic <number>" after including   //
-// "y_malloc" (or another library that eventually includes "y_malloc").       //
-// Because that library allocates memory from the heap, it needs control over //
-// how much memory is in the heap to begin with.  You do this with            //
-// "#pragma dynamic <number>", which that library does.  Because using that a //
-// second time somewhere in your mode will break "y_malloc", it disables the  //
-// pragma, and instead outputs that error.  If you need to increase your      //
-// stack or heap size (due to a stack/heap collision), add this to the very   //
-// top of your mode:                                                          //
-//                                                                            //
-//   #define DYNAMIC_MEMORY <number>                                          //
-//                                                                            //
-// ========================================================================== //
 
 // Sort of "module local" variables.
 stock
@@ -216,14 +223,35 @@ stock
 #define YSI_g_sHeapStart __YSI_g_sHeapStart
 #define YSI_g_sUnusedStart __YSI_g_sUnusedStart
 
-new
-	YSI_gMallocMemory[1];
-
 forward Alloc:Malloc_Allocate(size, const bool:clear = true);
 forward Alloc:calloc(size);
 
-// Allocate space on the heap permanently.
-#include "y_malloc/heapalloc"
+#if defined YSI_NO_HEAP_MALLOC
+	new
+		YSI_gMallocMemory[MALLOC_MEMORY];
+	
+	public OnScriptInit()
+	{
+		YSI_g_sHeapStart = 0;
+		YSI_gMallocMemory[0] = MALLOC_MEMORY - 1;
+		YSI_g_sUnusedStart = 1;
+		memset(YSI_gMallocMemory[1], 0, MALLOC_MEMORY - 1);
+		return 1;
+	}
+	
+	#undef OnScriptInit
+	#define OnScriptInit Malloc_OnScriptInit
+	#if defined Malloc_OnScriptInit
+		forward Malloc_OnScriptInit();
+	#endif
+#else
+	new
+		YSI_gMallocMemory[1];
+	
+	// Allocate space on the heap permanently.
+	#include "y_malloc/heapalloc"
+#endif
+
 // Functions to access the data on the heap.
 #include "y_malloc/funcs"
 #if defined YSI_TESTS

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -160,7 +160,10 @@ Operators:
 
 // Allocate extra memory for the normal stack and heap (64k, 16 times the size
 // of the default stack)!
-#pragma dynamic MALLOC_MEMORY + 65536
+#if !defined DYNAMIC_MEMORY
+    #define DYNAMIC_MEMORY (65536)
+#endif
+#pragma dynamic MALLOC_MEMORY + DYNAMIC_MEMORY
 
 // Sort of "module local" variables.
 stock

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -236,6 +236,9 @@ forward Alloc:calloc(size);
 		YSI_gMallocMemory[0] = MALLOC_MEMORY - 1;
 		YSI_g_sUnusedStart = 1;
 		memset(YSI_gMallocMemory[1], 0, MALLOC_MEMORY - 1);
+		#if defined Malloc_OnScriptInit
+			Malloc_OnScriptInit();
+		#endif
 		return 1;
 	}
 	

--- a/YSI_Coding/y_malloc.inc
+++ b/YSI_Coding/y_malloc.inc
@@ -136,8 +136,7 @@ Operators:
 #include "..\YSI_Core\y_als"
 #include "..\YSI_Core\y_utils"
 
-#include "..\amx\opcode"
-#include "..\amx\stack_trace"
+#include "..\YSI_Internal\amx_assembly"
 
 #define MALLOC_KB_TO_CELL ((1024 * 8) / cellbits)
 

--- a/YSI_Core/y_functional.inc
+++ b/YSI_Core/y_functional.inc
@@ -10,10 +10,7 @@
 #include "..\YSI_Storage\y_amx"
 #include "..\YSI_Coding\y_inline"
 
-#include "..\amx\disasm"
-#include "..\amx\asm"
-#include "..\amx\frame_info"
-
+#include "..\YSI_Internal\amx_assembly"
 #include "y_functional/impl"
 #include "y_functional/rewrite"
 

--- a/YSI_Core/y_testing.inc
+++ b/YSI_Core/y_testing.inc
@@ -68,6 +68,7 @@ Changelog:
 #include <a_samp>
 #include "y_debug"
 #include "..\YSI_Storage\y_amx"
+#include "..\YSI_Internal\amx_assembly"
 
 #if defined YSI_TESTS
 	#if defined INCLUDE_TESTS
@@ -139,6 +140,9 @@ static stock const
 	Y_TESTING_PSHUT = _A<y_@Q>;
 
 static stock
+	YSI_g_sCurTest = 0,
+	YSI_g_sFailTests = 0,
+	YSI_g_sInTest = false,
 	YSI_g_sTestResult,
 	YSI_g_sFailMessage[512],
 	YSI_g_sPlayer = cellmax,
@@ -146,14 +150,17 @@ static stock
 	YSI_g_sTests,
 	YSI_g_sFails;
 
+stock
+	YSI_gCurTestName[32];
+
 #if defined RUN_TESTS
-	#define Test:%1() forward bool:yQ@_%1(); public bool:yQ@_%1() for(new string:__name[]=#%1,bool:__once=(TEST_REPORT("*** Test %s start", __name) || TRUE);__once;__once=(TEST_REPORT(" ") && FALSE))
-	#define TestInit:%1() forward _yQ@%1(); public _yQ@%1() for(new string:__name[]=#%1,bool:__once=TRUE;__once;__once=(TEST_REPORT(" ", __name) && FALSE))
-	#define TestClose:%1() forward yQ_@%1(); public yQ_@%1() for(new string:__name[]=#%1,bool:__once=TRUE;__once;__once=(TEST_REPORT(" ", __name) && FALSE))
+	#define Test:%1() forward bool:yQ@_%1(); public bool:yQ@_%1() for(new bool:__once = (_Testing_Start("\0\0"#%1), TEST_REPORT("*** Test %s start", YSI_gCurTestName) || true); __once; __once = (TEST_REPORT(" ") && false))
+	#define TestInit:%1() forward _yQ@%1(); public _yQ@%1() for (new bool:__once = true; __once; __once = false)
+	#define TestClose:%1() forward yQ_@%1(); public yQ_@%1() for (new bool:__once = true; __once; __once = false)
 	
-	#define PTest:%1(%2) forward bool:_@yQ%1(%2); public bool:_@yQ%1(%2) for(new string:__name[]=#%1,bool:__once=(TEST_REPORT("*** Player Test %s start", __name) || TRUE);__once;__once=(TEST_REPORT(" ") && FALSE))
-	#define PTestInit:%1(%2) forward _y@Q%1(%2); public _y@Q%1(%2) for(new string:__name[]=#%1,bool:__once=TRUE;__once;__once=(TEST_REPORT(" ", __name) && FALSE))
-	#define PTestClose:%1(%2) forward y_@Q%1(%2); public y_@Q%1(%2) for(new string:__name[]=#%1,bool:__once=TRUE;__once;__once=(TEST_REPORT(" ", __name) && FALSE))
+	#define PTest:%1(%2) forward bool:_@yQ%1(%2); public bool:_@yQ%1(%2) for(new bool:__once = (_Testing_Start("\0\0"#%1), TEST_REPORT("*** Player Test %s start", YSI_gCurTestName) || true); __once; __once = (TEST_REPORT(" ") && false))
+	#define PTestInit:%1(%2) forward _y@Q%1(%2); public _y@Q%1(%2) for (new bool:__once = true; __once; __once = false)
+	#define PTestClose:%1(%2) forward y_@Q%1(%2); public y_@Q%1(%2) for (new bool:__once = true; __once; __once = false)
 #else
 	#define Test:%1() stock bool:yQ@_%1()
 	#define TestInit:%1() stock _yQ@%1()
@@ -174,6 +181,28 @@ static stock
 #include "..\YSI_Internal\y_natives"
 
 #include "..\YSI_Coding\y_va"
+
+/**--------------------------------------------------------------------------**\
+<summary>Testing_Start</summary>
+<param name="name">Name of the current function.</param>
+<returns>
+	-
+</returns>
+<remarks>
+	Gets a reference to the 
+</remarks>
+\**--------------------------------------------------------------------------**/
+
+stock _Testing_Start(name[])
+{
+	// Gets a reference to the name string, which is also an intrusive linked
+	// list of failures.
+	name[0] = name[1] = 0,
+	YSI_g_sCurTest = ref(name);
+	printf("_Testing_Start %d %d %s = %d", name[0], name[1], name[2], YSI_g_sCurTest);
+	YSI_gCurTestName[0] = '\0',
+	strcpy(YSI_gCurTestName, name[2]);
+}
 
 /**--------------------------------------------------------------------------**\
 <summary>Testing_Ask</summary>
@@ -244,46 +273,55 @@ stock bool:Testing_Run(&tests, &fails, lastfail[33] = "", bool:p = false)
 {
 	P:3("bool:Testing_Run called: %i, %i, \"%s\", %i", tests, fails, lastfail, p);
 	#pragma unused p, lastfail
-	#if defined RUN_TESTS
-		P:2("Testing_Run() called");
-		new
-			idx,
-			buffer[32];
-		while ((idx = AMX_GetPublicNamePrefix(idx, buffer, Y_TESTING_TEST)))
-		{
-			strunpack(buffer, buffer);
-			// Call the setup function if there is one.
-			buffer[0] = '_';
-			buffer[1] = 'y';
-			buffer[2] = 'Q';
-			buffer[3] = '@';
-			CallLocalFunction(buffer, "");
-			// Call the test.
-			buffer[0] = 'y';
-			buffer[1] = 'Q';
-			buffer[2] = '@';
-			buffer[3] = '_';
-			fails = YSI_g_sFails;
-			P:5("Testing_Run(): Calling %s", unpack(buffer[1]));
-			CallLocalFunction(buffer, "");
-			#if !defined TEST_SHOW_PASSES
-				if (YSI_g_sFails == fails)
-				{
-					TEST_REPORT(TEST_PASSED);
-					TEST_REPORT(" ");
-				}
-			#endif
-			buffer[2] = '_';
-			buffer[3] = '@';
-			CallLocalFunction(buffer, "");
-		}
-		tests = YSI_g_sTests;
+#if defined RUN_TESTS
+	P:2("Testing_Run() called");
+	new
+		idx,
+		buffer[32];
+	YSI_g_sCurTest = YSI_g_sFailTests = 0;
+	while ((idx = AMX_GetPublicNamePrefix(idx, buffer, Y_TESTING_TEST)))
+	{
+		strunpack(buffer, buffer);
+		// Call the setup function if there is one.
+		buffer[0] = '_',
+		buffer[1] = 'y',
+		buffer[2] = 'Q',
+		buffer[3] = '@',
+		CallLocalFunction(buffer, "");
+		// Call the test.
+		buffer[0] = 'y',
+		buffer[1] = 'Q',
+		buffer[2] = '@',
+		buffer[3] = '_',
 		fails = YSI_g_sFails;
-		return fails == 0;
-	#else
-		#pragma unused tests, fails, lastfail
-		return true;
-	#endif
+		P:5("Testing_Run(): Calling %s", unpack(buffer[1]));
+		YSI_g_sInTest = true;
+		CallLocalFunction(buffer, "");
+		YSI_g_sInTest = false;
+		if (YSI_g_sFails != fails)
+		{
+			WriteAmxMemory(YSI_g_sCurTest, YSI_g_sFailTests),
+			WriteAmxMemory(YSI_g_sCurTest + 4, YSI_g_sFails - fails),
+			YSI_g_sFailTests = YSI_g_sCurTest;
+		}
+#if !defined TEST_SHOW_PASSES
+		else
+		{
+			TEST_REPORT(TEST_PASSED);
+			TEST_REPORT(" ");
+		}
+#endif
+		buffer[2] = '_',
+		buffer[3] = '@',
+		CallLocalFunction(buffer, "");
+	}
+	tests = YSI_g_sTests;
+	fails = YSI_g_sFails;
+	return fails == 0;
+#else
+	#pragma unused tests, fails, lastfail
+	return true;
+#endif
 }
 
 /**--------------------------------------------------------------------------**\
@@ -326,14 +364,15 @@ stock bool:Testing_Player(playerid, &idx, &tests, &fails, lastfail[33] = "", boo
 			buffer[2] = 'y';
 			fails = YSI_g_sFails;
 			P:5("Testing_Player(): Calling %s", buffer[6]);
+			YSI_g_sInTest = true;
 			CallLocalFunction(buffer, "");
-			#if !defined TEST_SHOW_PASSES
-				if (YSI_g_sFails == fails)
-				{
-					TEST_REPORT(TEST_PASSED);
-					TEST_REPORT(" ");
-				}
-			#endif
+#if !defined TEST_SHOW_PASSES
+		if (YSI_g_sFails == fails)
+		{
+			TEST_REPORT(TEST_PASSED);
+			TEST_REPORT(" ");
+		}
+#endif
 		}
 		tests = YSI_g_sTests;
 		fails = YSI_g_sFails;
@@ -388,6 +427,7 @@ forward OnTestsComplete(tests, fails);
 	
 	Testing_Next(playerid)
 	{
+		YSI_g_sInTest = false;
 		new
 			buffer[32];
 		for ( ; ; )
@@ -420,6 +460,7 @@ forward OnTestsComplete(tests, fails);
 				buffer[1] = '@';
 				buffer[2] = 'y';
 				P:5("Testing_Next(): Calling %s", unpack(buffer[1]));
+				YSI_g_sInTest = true;
 				CallLocalFunction(buffer, "i", playerid);
 			}
 			else
@@ -490,7 +531,12 @@ forward OnTestsComplete(tests, fails);
 	
 	public OnRuntimeError(code, &bool:suppress)
 	{
-		++YSI_g_sFails;
+		if (YSI_g_sInTest)
+		{
+			// Fail the current test if we see any runtime errors.  Requires the
+			// crashdetect plugin to function, but not to compile and run.
+			Testing_Test(false, "Runtime error detected");
+		}
 		#if defined Testing_OnRuntimeError
 			return Testing_OnRuntimeError(code, suppress);
 		#else
@@ -556,14 +602,24 @@ stock Testing_RunAll()
 	else
 	{
 		printf("*** Tests: %d, Fails: %d", tests, fails);
-		TEST_REPORT(" ");
-		if (!fails)
+		if (fails)
 		{
+			// List all the failing tests, along with the number of "ASSERT"s
+			// that didn't pass.
+			while (YSI_g_sFailTests != 0)
+			{
+				printf("    - Test:%s (%d)", deref(YSI_g_sFailTests + 8), ReadAmxMemory(YSI_g_sFailTests + 4)),
+				YSI_g_sFailTests = ReadAmxMemory(YSI_g_sFailTests);
+			}
+		}
+		else
+		{
+			TEST_REPORT(" ");
 			TEST_REPORT("  ||===================||  ");
 			TEST_REPORT("  || ALL TESTS PASSED! ||  ");
 			TEST_REPORT("  ||===================||  ");
-			TEST_REPORT(" ");
 		}
+		TEST_REPORT(" ");
 	}
 	//state ysi_debug : on;
 	CallLocalFunction("OnTestsComplete", "ii", tests, fails);

--- a/YSI_Core/y_testing.inc
+++ b/YSI_Core/y_testing.inc
@@ -199,7 +199,7 @@ stock _Testing_Start(name[])
 	// list of failures.
 	name[0] = name[1] = 0,
 	YSI_g_sCurTest = ref(name);
-	printf("_Testing_Start %d %d %s = %d", name[0], name[1], name[2], YSI_g_sCurTest);
+	P:3("_Testing_Start %d %d %s = %d", name[0], name[1], name[2], YSI_g_sCurTest);
 	YSI_gCurTestName[0] = '\0',
 	strcpy(YSI_gCurTestName, name[2]);
 }

--- a/YSI_Core/y_utils.inc
+++ b/YSI_Core/y_utils.inc
@@ -122,6 +122,10 @@ new stock
 	NULL[2] = "\1";
 #endif
 
+#if !defined cellbytes
+	#define cellbytes (cellbits / 8)
+#endif
+
 #define UNSIGNED(%0) ((%0) - cellmin)
 
 // Define "volatile" as nothing.

--- a/YSI_Core/y_utils.inc
+++ b/YSI_Core/y_utils.inc
@@ -92,9 +92,7 @@ Variables:
 #include "..\YSI_Storage\y_amx"
 //#tryinclude <sscanf>
 
-#include "..\amx\asm"
-//asm"
-
+#include "..\YSI_Internal\amx_assembly"
 // Add new tags to the START of this list.
 #include "..\YSI_Internal\y_globaltags"
 

--- a/YSI_Data/y_foreach/impl.inc
+++ b/YSI_Data/y_foreach/impl.inc
@@ -479,10 +479,6 @@ native Iter_RandomAdd(Iterator:Name<>);
 </remarks>
 \**--------------------------------------------------------------------------**/
 
-//#define Iter_RandomAdd _ITER<RandomAdd>
-//#define Iter_RandomAdd_InternalA(%0,%1)    Iter_RandomAdd_InternalC(%0,%1,F@s(%1)-1)
-//#define Iter_RandomAdd_InternalB(%0,%2,%1) Iter_RandomAdd_InternalD(%0,%1,F@s(%1)-F@s(%0),F@s(%0),F@s(%1)-1-(%2),%2)
-
 #define Iter_RandomAdd(%0) Iter_Add(%0,Iter_RandomFree(%0))
 
 /**--------------------------------------------------------------------------**\
@@ -498,10 +494,6 @@ native Iter_RandomRemove(Iterator:Name<>);
 
 </remarks>
 \**--------------------------------------------------------------------------**/
-
-//#define Iter_RandomRemove _ITER<RandomRemove>
-//#define Iter_RandomRemove_InternalA(%0,%1)    Iter_RandomRemove_InternalC(%0,%1,F@s(%1)-1)
-//#define Iter_RandomRemove_InternalB(%0,%2,%1) Iter_RandomRemove_InternalD(%0,%1,F@s(%1)-F@s(%0),F@s(%0),F@s(%1)-1-(%2),%2)
 
 #define Iter_RandomRemove(%0) Iter_Remove(%0,Iter_Random(%0))
 

--- a/YSI_Data/y_foreach/impl.inc
+++ b/YSI_Data/y_foreach/impl.inc
@@ -895,7 +895,10 @@ native Iter_FastClear(IteratorArray:Name[]<>);
 #define F@y:%0(%1) Iter_Func@%0(%1)F@a$
 
 // Local state for iterator functions that need more than one variable.
-#define iterstate(%5,%6)%9);%9!=_:(%1=%2( %5),Iter_State@%1[]={%6};_:(%5)!=_:(%1=%2(Iter_State@%1,
+#define iterstate(%5,%6)%9);%9!=_:(%1=%2( %5),itrst:Iter_State@%1=itrst:(%6);_:(%5)!=_:(%1=%2(_:Iter_State@%1,
+
+// Make the internal state an array if there is more than one value.
+#define itrst:%1=itrst:(%6,%7) %1[]={%6,%7}
 
 // Consume spaces in the iterator state variables.
 #define Iter_State@%0\32;%1) Iter_State@%0%1)

--- a/YSI_Data/y_foreach/impl.inc
+++ b/YSI_Data/y_foreach/impl.inc
@@ -289,7 +289,7 @@ Array:
 </remarks>
 \**--------------------------------------------------------------------------**/
 
-#define iterstart@Reverse%9$);_:(%1=%9(_:%9,%0))%9; F@p:F@q:$%1,%0$
+#define iterstart@Reverse%9$);%9!=_:(%1=%9(_:%9,%0)); F@p:F@q:$%1,%0$
 
 /*
 
@@ -835,13 +835,6 @@ native Iter_FastClear(IteratorArray:Name[]<>);
 #define Iter_Func@public%0(%2)%1$ public F@y:%0(%2)
 #define Iter_Func@forward%0(%2)%1$ forward F@y:%0(%2)
 
-// #define iterstart@stock%0=%1(%2) stock F@y:%0(%2)
-// #define iterstart@static%0=%1(%2) static F@y:%0(%2)
-// #define iterstart@foreign%0=%1(%2) foreign F@y:%0(%2)
-// #define iterstart@global%0=%1(%2) global F@y:%0(%2)
-// #define iterstart@public%0=%1(%2) public F@y:%0(%2)
-// #define iterstart@forward%0=%1(%2) forward F@y:%0(%2)
-
 // A nice "match" symbol that we can scan for, then remove after it is used.
 #define F@a$
 #define F@b|||
@@ -884,7 +877,7 @@ native Iter_FastClear(IteratorArray:Name[]<>);
 #define F@n:%9$%1,%0<%2>$ F@s(Iterator@%0)-1-(%2));_:(%1=F@h:Iterator@%0[%1])<(F@s(Iterator@%0)-F@s(Iter_Multi@%0));
 
 // Special iterator.
-#define F@l:%9$%1,%0(%2)%8$ F@r(iterstart@%0));_:(%1=F@h:Iter_Func@%0(_:%1,%2))!=F@r(iterstart@%0);
+#define F@l:%9$%1,%0(%2)%8$ F@r(iterstart@%0));_:(F@r(iterstart@%0))!=_:(%1=F@h:Iter_Func@%0(_:%1,%2));
 
 // Normal iterator.
 #define F@m:%9$%1,%0$ F@s(Iterator@%0)-1);_:(%1=F@h:Iterator@%0[%1])!=(F@s(Iterator@%0)-1);
@@ -898,15 +891,14 @@ native Iter_FastClear(IteratorArray:Name[]<>);
 // Reverse normal iterator.
 #define F@q:%9$%1,%0$ F@s(Iterator@%0)-1);_:(%1=Iter_Prev_InternalA(,Iterator@%0,%1))!=(F@s(Iterator@%0)-1);
 
-// Declare a 
-//#define F@y:%0(%1) Iter_Func@%0(%1);const iterstart@%0=_:F@t:-1;Iter_Func@%0(%1)F@a$
-
-// Detect __declspec(stock)
-//#define F@t:-1;%0$__declspec(%1) F@t:-1;%1 %0$
-//#define __declspec_stock
-//#define stock%0\n%1 %0=
-
+// Special iterator function declaration.
 #define F@y:%0(%1) Iter_Func@%0(%1)F@a$
+
+// Local state for iterator functions that need more than one variable.
+#define iterstate(%5,%6)%9);%9!=_:(%1=%2( %5),Iter_State@%1[]={%6};_:(%5)!=_:(%1=%2(Iter_State@%1,
+
+// Consume spaces in the iterator state variables.
+#define Iter_State@%0\32;%1) Iter_State@%0%1)
 
 /**--------------------------------------------------------------------------**\
 	The workings of these macros are very extensively documented at:
@@ -941,6 +933,13 @@ native Iter_FastClear(IteratorArray:Name[]<>);
 #define Y_FOREACH_SECOND|||Y_FOREACH_THIRD|||%2,%1||| using_deprecated_foreach_syntax,%1=_Y_ITER_DO_FOREACH(%1,%2)++using_deprecated_foreach_syntax
 
 stock const
+	// This variable is re-declared when you do "foreach (Player, i)" or similar
+	// so that a warning is generated.  The warning will read:
+	//   
+	//   local variable "using_deprecated_foreach_syntax" shadows a variable at a preceding level
+	//   
+	// This is the best I could do to warn about the old syntax.  That code
+	// should now be "foreach (new i : Player)".  It may become an error later.
 	bool:using_deprecated_foreach_syntax = false,
 	F@o[2];
 

--- a/YSI_Data/y_foreach/iterators.inc
+++ b/YSI_Data/y_foreach/iterators.inc
@@ -655,6 +655,7 @@ hook OnScriptInit()
 			new
 				ret = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay, addsiren);
 		#else
+			#pragma unused addsiren
 			new
 				ret = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay);
 		#endif
@@ -696,6 +697,7 @@ hook OnScriptInit()
 			new
 				ret = AddStaticVehicleEx(modelid, spawn_x, spawn_y, spawn_z, angle, color1, color2, respawn_delay, addsiren);
 		#else
+			#pragma unused addsiren
 			new
 				ret = AddStaticVehicleEx(modelid, spawn_x, spawn_y, spawn_z, angle, color1, color2, respawn_delay);
 		#endif

--- a/YSI_Data/y_foreach/iterators.inc
+++ b/YSI_Data/y_foreach/iterators.inc
@@ -381,6 +381,47 @@ stock iterfunc Filter(cur, val, arr[], size = sizeof (arr))
 
 #define iterstart@Filter (-1)
 
+#define Iter_Func@None(%0,%1) _ITER<None>(%1,%0)
+#define iterstart@None (-1)
+#define Iter_None_InternalA(%0,%1,%9) Iter_None_Internal(%1,F@s(%1)-1,%9)
+#define Iter_None_InternalB(%0,%2,%1,%9) Iter_None_Internal(%1,F@s(%1)-F@s(%0),%9)
+
+stock Iter_None_Internal(array[], size, value)
+{
+	// Loop over all values NOT in any iterator.  Similar to repeatedly calling
+	// "Iter_Free", though that will return the same value twice if called twice
+	// in a row.  Instead, this function will loop through the missing ones.
+	while (++value < size)
+	{
+		if (array[value] <= value)
+		{
+			return value;
+		}
+	}
+	return -1;
+}
+
+#define Iter_Func@All(%0,%1) _ITER<All>(%1,%0)
+#define iterstart@All (-1)
+#define Iter_All_InternalA(%0,%1,%9) Iter_All_Internal(%1,F@s(%1)-1,%9)
+#define Iter_All_InternalB(%0,%2,%1,%9) Iter_All_Internal(%1,F@s(%1)-F@s(%0),%9)
+
+stock Iter_All_Internal(array[], size, value)
+{
+	// Loop over all values in any iterator.  This is different to looping over
+	// the iterator normally for multi-dimensional iterators, since it will
+	// return all values in ANY iterator in their numerical order.  For single-
+	// dimensional iterators it is exactly the same, just a little slower.
+	while (++value < size)
+	{
+		if (array[value] > value)
+		{
+			return value;
+		}
+	}
+	return -1;
+}
+
 /*
 
     88        88                         88                   

--- a/YSI_Data/y_foreach/iterators.inc
+++ b/YSI_Data/y_foreach/iterators.inc
@@ -258,7 +258,7 @@ stock iterfunc Range(cur, min, max, step = 1)
 
 #define iterstart@Range cellmin
 
-stock iterfunc Powers(cur, base)
+stock iterfunc Powers(&iterstate, cur, base)
 {
 	// Returns all the powers of the given number that can be stored in a PAWN
 	// cell.
@@ -268,21 +268,18 @@ stock iterfunc Powers(cur, base)
 	//       // 3^0, 3^1, 3^2, 3^3, etc...
 	//   }
 	//   
-	// Like "Random", this has internal state so cannot currently be nested.
-	static
-		next = 0;
 	if (cur)
 	{
 		return
-			next = base * cur,
-			_:(next > cur) * next;
+			iterstate = base * cur,
+			_:(iterstate > cur) * iterstate;
 	}
 	return 1;
 }
 
-#define iterstart@Powers 0
+#define iterstart@Powers iterstate(0, 0)
 
-stock iterfunc Fib(cur)
+stock iterfunc Fib(&iterstate, cur)
 {
 	// Returns every number in the Fibaonacci sequence that can be stored in a
 	// PAWN cell.
@@ -291,38 +288,23 @@ stock iterfunc Fib(cur)
 	//   {
 	//   }
 	//   
-	// Like "Random", this has internal state so cannot currently be nested.
-	static
-		prev = -1,
-		next = 0;
-	if (cur == -1)
+	switch (cur)
 	{
-		return
-			prev = -1,
-			0;
-	}
-	else if (prev == -1)
-	{
-		return
-			prev = 0,
-			1;
-	}
-	else if (cur == 1836311903)
-	{
+	case -1:
+		return 0;
+	case 1836311903:
 		// End point (statically calculated largest Fibaonacci number that can
 		// be stored in a signed 32-bit integer.  Does make this not totally
 		// portable, because it can't be used in the 64-bit version quickly.
 		return -1;
 	}
-	return
-		next = prev + cur,
-		prev = cur,
-		next;
+	// Based on the "+--" swap method (like "^^^"), but without the last one.
+	return (iterstate = iterstate + cur) - cur;
 }
 
-#define iterstart@Fib (-1)
+#define iterstart@Fib iterstate(-1, 1)
 
-stock iterfunc Random(info[1], cur, count, min = cellmax, max = 0)
+stock iterfunc Random(&iterstate, cur, count, min = cellmax, max = 0)
 {
 	// Return a given count of random numbers:
 	//   
@@ -354,9 +336,9 @@ stock iterfunc Random(info[1], cur, count, min = cellmax, max = 0)
 	//   
 	if (cur == cellmin)
 	{
-		info[0] = 0;
+		iterstate = 0;
 	}
-	if (++info[0] > count)
+	if (++iterstate > count)
 	{
 		return cellmin;
 	}

--- a/YSI_Data/y_foreach/iterators.inc
+++ b/YSI_Data/y_foreach/iterators.inc
@@ -260,6 +260,15 @@ stock iterfunc Range(cur, min, max, step = 1)
 
 stock iterfunc Powers(cur, base)
 {
+	// Returns all the powers of the given number that can be stored in a PAWN
+	// cell.
+	//   
+	//   foreach (new i : Powers(3))
+	//   {
+	//       // 3^0, 3^1, 3^2, 3^3, etc...
+	//   }
+	//   
+	// Like "Random", this has internal state so cannot currently be nested.
 	static
 		next = 0;
 	if (cur)
@@ -275,6 +284,14 @@ stock iterfunc Powers(cur, base)
 
 stock iterfunc Fib(cur)
 {
+	// Returns every number in the Fibaonacci sequence that can be stored in a
+	// PAWN cell.
+	//   
+	//   foreach (new i : Fib())
+	//   {
+	//   }
+	//   
+	// Like "Random", this has internal state so cannot currently be nested.
 	static
 		prev = -1,
 		next = 0;
@@ -292,6 +309,9 @@ stock iterfunc Fib(cur)
 	}
 	else if (cur == 1836311903)
 	{
+		// End point (statically calculated largest Fibaonacci number that can
+		// be stored in a signed 32-bit integer.  Does make this not totally
+		// portable, because it can't be used in the 64-bit version quickly.
 		return -1;
 	}
 	return
@@ -302,38 +322,65 @@ stock iterfunc Fib(cur)
 
 #define iterstart@Fib (-1)
 
-stock iterfunc Random(cur, count, ...)
+stock iterfunc Random(info[1], cur, count, min = cellmax, max = 0)
 {
-	static
-		num = 0;
+	// Return a given count of random numbers:
+	//   
+	//   foreach (new i : Random(5))
+	//   {
+	//       // 5 random numbers.
+	//   }
+	//   
+	//   foreach (new i : Random(12, 10))
+	//   {
+	//       // 12 random numbers between 0 and 10 (0 to 9 inclusive).
+	//   }
+	//   
+	//   foreach (new i : Random(100, -10, 10))
+	//   {
+	//       // 100 random numbers between -10 and 10 (-10 to 9 inclusive).
+	//   }
+	//   
+	// Note that this function has internal state, so you cannot call this in a
+	// nested manner.  This will probably fail:
+	//   
+	//   foreach (new i : Random(10, 70))
+	//   {
+	//       foreach (new j : Random(10, 80))
+	//       {
+	//           // Will NOT get 100 randoms 0 to 80, plus 10 randoms 0 to 70.
+	//       }
+	//   }
+	//   
 	if (cur == cellmin)
 	{
-		num = 0;
+		info[0] = 0;
 	}
-	if (++num > count)
+	if (++info[0] > count)
 	{
 		return cellmin;
 	}
-	switch (numargs())
+	if (min >= max)
 	{
-		case 2:
-		{
-			return random(cellmax);
-		}
-		case 3:
-		{
-			return random(getarg(2));
-		}
+		return random(min);
 	}
-	return
-		count = getarg(2),
-		random(getarg(3) - count) + count;
+	else
+	{
+		return random(max - min) + min;
+	}
 }
 
-#define iterstart@Random cellmin
+#define iterstart@Random iterstate(cellmin, 0)
 
 stock iterfunc Null(cur, arr[], size = sizeof (arr))
 {
+	// Loop over all the indexes of this array that are zero.
+	//   
+	//   new array[] = { ... };
+	//   foreach (new i : Null(array))
+	//   {
+	//   }
+	//   
 	while (++cur < size)
 	{
 		if (!arr[cur])
@@ -348,6 +395,13 @@ stock iterfunc Null(cur, arr[], size = sizeof (arr))
 
 stock iterfunc NonNull(cur, arr[], size = sizeof (arr))
 {
+	// Loop over all the indexes of this array that are not zero.
+	//   
+	//   new array[] = { ... };
+	//   foreach (new i : NonNull(array))
+	//   {
+	//   }
+	//   
 	while (++cur < size)
 	{
 		if (arr[cur])
@@ -362,6 +416,13 @@ stock iterfunc NonNull(cur, arr[], size = sizeof (arr))
 
 stock iterfunc Until(cur, val, arr[], size = sizeof (arr))
 {
+	// Loop over all the indexes of this array until one equals the given value:
+	//   
+	//   new array[] = { ... };
+	//   foreach (new i : Until(5, array))
+	//   {
+	//   }
+	//   
 	return (++cur >= size || arr[cur] == val) ? -1 : cur;
 }
 

--- a/YSI_Data/y_foreach/tests.inc
+++ b/YSI_Data/y_foreach/tests.inc
@@ -2738,3 +2738,67 @@ Test:y_iter_Until()
 	ASSERT(c == 6);
 }
 
+Test:y_iter_All1()
+{
+	new Iterator:a<10>;
+	Iter_Add(a, 3);
+	Iter_Add(a, 4);
+	Iter_Add(a, 7);
+	Iter_Add(a, 9);
+	new count = 0;
+	foreach (new i : All(a))
+	{
+		ASSERT(i == 3 || i == 4 || i == 7 || i == 9);
+		++count;
+	}
+	ASSERT(count == 4);
+}
+
+Test:y_iter_None1()
+{
+	new Iterator:a<10>;
+	Iter_Add(a, 3);
+	Iter_Add(a, 4);
+	Iter_Add(a, 7);
+	Iter_Add(a, 9);
+	new count = 0;
+	foreach (new i : None(a))
+	{
+		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
+		++count;
+	}
+	ASSERT(count == 6);
+}
+
+Test:y_iter_All2()
+{
+	new Iterator:a<3, 10>;
+	Iter_Add(a<0>, 3);
+	Iter_Add(a<2>, 4);
+	Iter_Add(a<2>, 7);
+	Iter_Add(a<1>, 9);
+	new count = 0;
+	foreach (new i : All(a<>))
+	{
+		ASSERT(i == 3 || i == 4 || i == 7 || i == 9);
+		++count;
+	}
+	ASSERT(count == 4);
+}
+
+Test:y_iter_None2()
+{
+	new Iterator:a<3, 10>;
+	Iter_Add(a<2>, 3);
+	Iter_Add(a<0>, 4);
+	Iter_Add(a<0>, 7);
+	Iter_Add(a<0>, 9);
+	new count = 0;
+	foreach (new i : None(a<>))
+	{
+		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
+		++count;
+	}
+	ASSERT(count == 6);
+}
+

--- a/YSI_Data/y_foreach/tests.inc
+++ b/YSI_Data/y_foreach/tests.inc
@@ -2648,6 +2648,22 @@ Test:y_iter_Random()
 	ASSERT(c == 1010);
 }
 
+Test:y_iter_RandomNested()
+{
+	new
+		c = 0;
+	foreach (new i : Random(10, 20))
+	{
+		ASSERT(0 <= i < 20);
+		foreach (new j : Random(10, -20, 20))
+		{
+			ASSERT(-20 <= j < 20);
+			++c;
+		}
+	}
+	ASSERT(c == 100);
+}
+
 Test:y_iter_Powers()
 {
 	new
@@ -2762,7 +2778,7 @@ Test:y_iter_None1()
 	Iter_Add(a, 7);
 	Iter_Add(a, 9);
 	new count = 0;
-	foreach (new i : All(a))
+	foreach (new i : None(a))
 	{
 		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
 		++count;
@@ -2794,7 +2810,7 @@ Test:y_iter_None2()
 	Iter_Add(a<0>, 7);
 	Iter_Add(a<0>, 9);
 	new count = 0;
-	foreach (new i : All(a<>))
+	foreach (new i : None(a<>))
 	{
 		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
 		++count;

--- a/YSI_Data/y_foreach/tests.inc
+++ b/YSI_Data/y_foreach/tests.inc
@@ -2818,4 +2818,3 @@ Test:y_iter_None2()
 	ASSERT(count == 6);
 }
 
-

--- a/YSI_Data/y_foreach/tests.inc
+++ b/YSI_Data/y_foreach/tests.inc
@@ -2762,7 +2762,7 @@ Test:y_iter_None1()
 	Iter_Add(a, 7);
 	Iter_Add(a, 9);
 	new count = 0;
-	foreach (new i : None(a))
+	foreach (new i : All(a))
 	{
 		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
 		++count;
@@ -2794,11 +2794,12 @@ Test:y_iter_None2()
 	Iter_Add(a<0>, 7);
 	Iter_Add(a<0>, 9);
 	new count = 0;
-	foreach (new i : None(a<>))
+	foreach (new i : All(a<>))
 	{
 		ASSERT(i != 3 && i != 4 && i != 7 && i != 9);
 		++count;
 	}
 	ASSERT(count == 6);
 }
+
 

--- a/YSI_Data/y_hashmap.inc
+++ b/YSI_Data/y_hashmap.inc
@@ -69,7 +69,7 @@ Definitions:
 #endif
 #define _INC_y_hashmap
 
-#include "..\amx\amx_memory"
+#include "..\YSI_Internal\amx_assembly"
 #include "..\YSI_Core\y_utils"
 #include "..\YSI_Storage\y_amx"
 #include "..\YSI_Coding\y_stringhash"

--- a/YSI_Internal/amx_assembly.inc
+++ b/YSI_Internal/amx_assembly.inc
@@ -35,7 +35,7 @@
 	#define AMX_INCLUDING_FAILED
 #endif
 #if !defined deref
-	#error Please update "https://github.com/Zeex/amx_assembly/tree/CodeScanner" to get "deref()"
+	#error Please update "https://github.com/Zeex/amx_assembly" to get "deref()"
 #endif
 
 #tryinclude "..\amx\asm"
@@ -59,7 +59,7 @@
 #tryinclude "..\amx_assembly\codescan"
 #tryinclude "..\..\amx_assembly\codescan"
 #if !defined CODESCAN_INC
-	#error Please update "https://github.com/Zeex/amx_assembly/tree/CodeScanner" to get "codescan.inc"
+	#error Please update "https://github.com/Zeex/amx_assembly" to get "codescan.inc"
 #endif
 
 #tryinclude "..\amx\disasm"

--- a/YSI_Internal/amx_assembly.inc
+++ b/YSI_Internal/amx_assembly.inc
@@ -1,0 +1,153 @@
+// If the files only exist in one place, they will only be included once because
+// of using "#tryinclude".  If they happen to exist in two places, their own
+// internal include guards (or the compiler's one) will prevent their multiple
+// inclusions.  I don't know why I ever made YSI use its own internal version...
+
+#tryinclude "..\amx\amx"
+#tryinclude <amx_assembly\amx>
+#tryinclude "..\amx_assembly\amx"
+#tryinclude "..\..\amx_assembly\amx"
+#if !defined AMX_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\amx_base"
+#tryinclude <amx_assembly\amx_base>
+#tryinclude "..\amx_assembly\amx_base"
+#tryinclude "..\..\amx_assembly\amx_base"
+#if !defined AMX_BASE_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\amx_header"
+#tryinclude <amx_assembly\amx_header>
+#tryinclude "..\amx_assembly\amx_header"
+#tryinclude "..\..\amx_assembly\amx_header"
+#if !defined AMX_HEADER_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\amx_memory"
+#tryinclude <amx_assembly\amx_memory>
+#tryinclude "..\amx_assembly\amx_memory"
+#tryinclude "..\..\amx_assembly\amx_memory"
+#if !defined AMX_MEMORY_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\asm"
+#tryinclude <amx_assembly\asm>
+#tryinclude "..\amx_assembly\asm"
+#tryinclude "..\..\amx_assembly\asm"
+#if !defined ASM_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\asm_macros"
+#tryinclude <amx_assembly\asm_macros>
+#tryinclude "..\amx_assembly\asm_macros"
+#tryinclude "..\..\amx_assembly\asm_macros"
+#if !defined ASM_MACROS_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\codescan"
+#tryinclude <amx_assembly\codescan>
+#tryinclude "..\amx_assembly\codescan"
+#tryinclude "..\..\amx_assembly\codescan"
+#if !defined CODESCAN_INC
+	#error Please update "https://github.com/Zeex/amx_assembly" to get "codescan.inc"
+#endif
+
+#tryinclude "..\amx\disasm"
+#tryinclude <amx_assembly\disasm>
+#tryinclude "..\amx_assembly\disasm"
+#tryinclude "..\..\amx_assembly\disasm"
+#if !defined DISASM_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\dynamic_call"
+#tryinclude <amx_assembly\dynamic_call>
+#tryinclude "..\amx_assembly\dynamic_call"
+#tryinclude "..\..\amx_assembly\dynamic_call"
+#if !defined DYNAMIC_CALL_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\frame_info"
+#tryinclude <amx_assembly\frame_info>
+#tryinclude "..\amx_assembly\frame_info"
+#tryinclude "..\..\amx_assembly\frame_info"
+#if !defined FRAME_INFO_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\heap_alloc"
+#tryinclude <amx_assembly\heap_alloc>
+#tryinclude "..\amx_assembly\heap_alloc"
+#tryinclude "..\..\amx_assembly\heap_alloc"
+#if !defined HEAP_ALLOC_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\opcode"
+#tryinclude <amx_assembly\opcode>
+#tryinclude "..\amx_assembly\opcode"
+#tryinclude "..\..\amx_assembly\opcode"
+#if !defined OPCODE_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\os"
+#tryinclude <amx_assembly\os>
+#tryinclude "..\amx_assembly\os"
+#tryinclude "..\..\amx_assembly\os"
+#if !defined OS_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\phys_memory"
+#tryinclude <amx_assembly\phys_memory>
+#tryinclude "..\amx_assembly\phys_memory"
+#tryinclude "..\..\amx_assembly\phys_memory"
+#if !defined PHYS_MEMORY_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\profiler"
+#tryinclude <amx_assembly\profiler>
+#tryinclude "..\amx_assembly\profiler"
+#tryinclude "..\..\amx_assembly\profiler"
+#if !defined PROFILER_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+//#tryinclude "..\amx\shellcode"
+//#tryinclude <amx_assembly\shellcode>
+//#tryinclude "..\amx_assembly\shellcode"
+//#tryinclude "..\..\amx_assembly\shellcode"
+//#if !defined SHELLCODE_INC
+//	#define AMX_INCLUDING_FAILED
+//#endif
+
+#tryinclude "..\amx\stack_dump"
+#tryinclude <amx_assembly\stack_dump>
+#tryinclude "..\amx_assembly\stack_dump"
+#tryinclude "..\..\amx_assembly\stack_dump"
+#if !defined STACK_DUMP_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#tryinclude "..\amx\stack_trace"
+#tryinclude <amx_assembly\stack_trace>
+#tryinclude "..\amx_assembly\stack_trace"
+#tryinclude "..\..\amx_assembly\stack_trace"
+#if !defined STACK_TRACE_INC
+	#define AMX_INCLUDING_FAILED
+#endif
+
+#if defined AMX_INCLUDING_FAILED
+	#error Could not include "https://github.com/Zeex/amx_assembly" - ensure it is in <amx> or <amx_assembly>
+#endif
+

--- a/YSI_Internal/amx_assembly.inc
+++ b/YSI_Internal/amx_assembly.inc
@@ -34,6 +34,9 @@
 #if !defined AMX_MEMORY_INC
 	#define AMX_INCLUDING_FAILED
 #endif
+#if !defined deref
+	#error Please update "https://github.com/Zeex/amx_assembly/tree/CodeScanner" to get "deref()"
+#endif
 
 #tryinclude "..\amx\asm"
 #tryinclude <amx_assembly\asm>

--- a/YSI_Internal/amx_assembly.inc
+++ b/YSI_Internal/amx_assembly.inc
@@ -56,7 +56,7 @@
 #tryinclude "..\amx_assembly\codescan"
 #tryinclude "..\..\amx_assembly\codescan"
 #if !defined CODESCAN_INC
-	#error Please update "https://github.com/Zeex/amx_assembly" to get "codescan.inc"
+	#error Please update "https://github.com/Zeex/amx_assembly/tree/CodeScanner" to get "codescan.inc"
 #endif
 
 #tryinclude "..\amx\disasm"

--- a/YSI_Internal/y_cgen.inc
+++ b/YSI_Internal/y_cgen.inc
@@ -4,7 +4,7 @@
 #define _INC_y_cgen
 
 #include "..\YSI_Storage\y_amx"
-#include "..\amx\asm"
+#include "..\YSI_Internal\amx_assembly"
 
 // We use "STE" not a string literal as we are trying to use up code space, not
 // data space!

--- a/YSI_Internal/y_compilerpass.inc
+++ b/YSI_Internal/y_compilerpass.inc
@@ -127,3 +127,4 @@ static stock __COMPILER_SECOND_PASS() {}
 #if __Pawn == 0x030A
 	#define NESTED_ELLIPSIS
 #endif
+

--- a/YSI_Internal/y_unique.inc
+++ b/YSI_Internal/y_unique.inc
@@ -62,7 +62,18 @@ Changelog:
 	#undef _inc_y_unique
 #endif
 
+#if defined UNIQUE_FUNCTION
+	#undef UNIQUE_FUNCTION
+#endif
+
+// The "static stock const" values are used for debugging, since they will show
+// up in preprocessed dumps ("-l") with the value of "UNIQUE_SYMBOL" at that
+// moment, instead of its final value.
 #if defined UNIQUE_SYMBOL
+	#if UNIQUE_SYMBOL < 0 || UNIQUE_SYMBOL >= 1000
+		static stock const UNIQUE_SYMBOL_TOO_LARGE = UNIQUE_SYMBOL;
+		#error UNIQUE_SYMBOL out of range.
+	#endif
 	#if UNIQUE_SYMBOL < 100
 		static stock const UNIQUE_SYMBOL_LESS_THAN_100 = UNIQUE_SYMBOL;
 		#include "y_unique\_000_to_099"
@@ -98,9 +109,5 @@ Changelog:
 	static stock const UNIQUE_SYMBOL_DOESNT_EXIST;
 	#define UNIQUE_SYMBOL (0)
 	#define UNIQUE_FUNCTION<%0...%1> %0000%1
-#endif
-#if UNIQUE_SYMBOL < 0 || UNIQUE_SYMBOL >= 1000
-	static stock const UNIQUE_SYMBOL_TOO_LARGE = UNIQUE_SYMBOL;
-	#error UNIQUE_SYMBOL out of range.
 #endif
 

--- a/YSI_Internal/y_unique/_000_to_099.inc
+++ b/YSI_Internal/y_unique/_000_to_099.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #if UNIQUE_SYMBOL < 10
 	#if UNIQUE_SYMBOL == 0
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (1)
 		#define UNIQUE_FUNCTION<%0...%1> %0001%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 1
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (2)
 		#define UNIQUE_FUNCTION<%0...%1> %0002%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 2
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (3)
 		#define UNIQUE_FUNCTION<%0...%1> %0003%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 3
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (4)
 		#define UNIQUE_FUNCTION<%0...%1> %0004%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 4
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (5)
 		#define UNIQUE_FUNCTION<%0...%1> %0005%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 5
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (6)
 		#define UNIQUE_FUNCTION<%0...%1> %0006%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 6
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (7)
 		#define UNIQUE_FUNCTION<%0...%1> %0007%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 7
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (8)
 		#define UNIQUE_FUNCTION<%0...%1> %0008%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 8
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (9)
 		#define UNIQUE_FUNCTION<%0...%1> %0009%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 9
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (10)
 		#define UNIQUE_FUNCTION<%0...%1> %0010%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 20
 	#if UNIQUE_SYMBOL == 10
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (11)
 		#define UNIQUE_FUNCTION<%0...%1> %0011%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 11
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (12)
 		#define UNIQUE_FUNCTION<%0...%1> %0012%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 12
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (13)
 		#define UNIQUE_FUNCTION<%0...%1> %0013%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 13
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (14)
 		#define UNIQUE_FUNCTION<%0...%1> %0014%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 14
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (15)
 		#define UNIQUE_FUNCTION<%0...%1> %0015%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 15
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (16)
 		#define UNIQUE_FUNCTION<%0...%1> %0016%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 16
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (17)
 		#define UNIQUE_FUNCTION<%0...%1> %0017%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 17
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (18)
 		#define UNIQUE_FUNCTION<%0...%1> %0018%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 18
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (19)
 		#define UNIQUE_FUNCTION<%0...%1> %0019%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 19
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (20)
 		#define UNIQUE_FUNCTION<%0...%1> %0020%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 30
 	#if UNIQUE_SYMBOL == 20
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (21)
 		#define UNIQUE_FUNCTION<%0...%1> %0021%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 21
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (22)
 		#define UNIQUE_FUNCTION<%0...%1> %0022%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 22
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (23)
 		#define UNIQUE_FUNCTION<%0...%1> %0023%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 23
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (24)
 		#define UNIQUE_FUNCTION<%0...%1> %0024%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 24
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (25)
 		#define UNIQUE_FUNCTION<%0...%1> %0025%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 25
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (26)
 		#define UNIQUE_FUNCTION<%0...%1> %0026%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 26
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (27)
 		#define UNIQUE_FUNCTION<%0...%1> %0027%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 27
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (28)
 		#define UNIQUE_FUNCTION<%0...%1> %0028%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 28
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (29)
 		#define UNIQUE_FUNCTION<%0...%1> %0029%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 29
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (30)
 		#define UNIQUE_FUNCTION<%0...%1> %0030%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 40
 	#if UNIQUE_SYMBOL == 30
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (31)
 		#define UNIQUE_FUNCTION<%0...%1> %0031%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 31
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (32)
 		#define UNIQUE_FUNCTION<%0...%1> %0032%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 32
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (33)
 		#define UNIQUE_FUNCTION<%0...%1> %0033%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 33
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (34)
 		#define UNIQUE_FUNCTION<%0...%1> %0034%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 34
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (35)
 		#define UNIQUE_FUNCTION<%0...%1> %0035%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 35
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (36)
 		#define UNIQUE_FUNCTION<%0...%1> %0036%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 36
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (37)
 		#define UNIQUE_FUNCTION<%0...%1> %0037%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 37
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (38)
 		#define UNIQUE_FUNCTION<%0...%1> %0038%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 38
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (39)
 		#define UNIQUE_FUNCTION<%0...%1> %0039%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 39
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (40)
 		#define UNIQUE_FUNCTION<%0...%1> %0040%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 50
 	#if UNIQUE_SYMBOL == 40
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (41)
 		#define UNIQUE_FUNCTION<%0...%1> %0041%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 41
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (42)
 		#define UNIQUE_FUNCTION<%0...%1> %0042%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 42
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (43)
 		#define UNIQUE_FUNCTION<%0...%1> %0043%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 43
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (44)
 		#define UNIQUE_FUNCTION<%0...%1> %0044%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 44
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (45)
 		#define UNIQUE_FUNCTION<%0...%1> %0045%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 45
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (46)
 		#define UNIQUE_FUNCTION<%0...%1> %0046%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 46
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (47)
 		#define UNIQUE_FUNCTION<%0...%1> %0047%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 47
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (48)
 		#define UNIQUE_FUNCTION<%0...%1> %0048%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 48
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (49)
 		#define UNIQUE_FUNCTION<%0...%1> %0049%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 49
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (50)
 		#define UNIQUE_FUNCTION<%0...%1> %0050%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 60
 	#if UNIQUE_SYMBOL == 50
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (51)
 		#define UNIQUE_FUNCTION<%0...%1> %0051%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 51
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (52)
 		#define UNIQUE_FUNCTION<%0...%1> %0052%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 52
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (53)
 		#define UNIQUE_FUNCTION<%0...%1> %0053%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 53
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (54)
 		#define UNIQUE_FUNCTION<%0...%1> %0054%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 54
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (55)
 		#define UNIQUE_FUNCTION<%0...%1> %0055%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 55
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (56)
 		#define UNIQUE_FUNCTION<%0...%1> %0056%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 56
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (57)
 		#define UNIQUE_FUNCTION<%0...%1> %0057%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 57
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (58)
 		#define UNIQUE_FUNCTION<%0...%1> %0058%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 58
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (59)
 		#define UNIQUE_FUNCTION<%0...%1> %0059%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 59
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (60)
 		#define UNIQUE_FUNCTION<%0...%1> %0060%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 70
 	#if UNIQUE_SYMBOL == 60
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (61)
 		#define UNIQUE_FUNCTION<%0...%1> %0061%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 61
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (62)
 		#define UNIQUE_FUNCTION<%0...%1> %0062%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 62
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (63)
 		#define UNIQUE_FUNCTION<%0...%1> %0063%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 63
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (64)
 		#define UNIQUE_FUNCTION<%0...%1> %0064%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 64
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (65)
 		#define UNIQUE_FUNCTION<%0...%1> %0065%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 65
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (66)
 		#define UNIQUE_FUNCTION<%0...%1> %0066%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 66
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (67)
 		#define UNIQUE_FUNCTION<%0...%1> %0067%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 67
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (68)
 		#define UNIQUE_FUNCTION<%0...%1> %0068%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 68
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (69)
 		#define UNIQUE_FUNCTION<%0...%1> %0069%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 69
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (70)
 		#define UNIQUE_FUNCTION<%0...%1> %0070%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 80
 	#if UNIQUE_SYMBOL == 70
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (71)
 		#define UNIQUE_FUNCTION<%0...%1> %0071%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 71
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (72)
 		#define UNIQUE_FUNCTION<%0...%1> %0072%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 72
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (73)
 		#define UNIQUE_FUNCTION<%0...%1> %0073%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 73
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (74)
 		#define UNIQUE_FUNCTION<%0...%1> %0074%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 74
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (75)
 		#define UNIQUE_FUNCTION<%0...%1> %0075%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 75
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (76)
 		#define UNIQUE_FUNCTION<%0...%1> %0076%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 76
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (77)
 		#define UNIQUE_FUNCTION<%0...%1> %0077%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 77
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (78)
 		#define UNIQUE_FUNCTION<%0...%1> %0078%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 78
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (79)
 		#define UNIQUE_FUNCTION<%0...%1> %0079%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 79
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (80)
 		#define UNIQUE_FUNCTION<%0...%1> %0080%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 90
 	#if UNIQUE_SYMBOL == 80
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (81)
 		#define UNIQUE_FUNCTION<%0...%1> %0081%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 81
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (82)
 		#define UNIQUE_FUNCTION<%0...%1> %0082%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 82
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (83)
 		#define UNIQUE_FUNCTION<%0...%1> %0083%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 83
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (84)
 		#define UNIQUE_FUNCTION<%0...%1> %0084%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 84
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (85)
 		#define UNIQUE_FUNCTION<%0...%1> %0085%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 85
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (86)
 		#define UNIQUE_FUNCTION<%0...%1> %0086%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 86
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (87)
 		#define UNIQUE_FUNCTION<%0...%1> %0087%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 87
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (88)
 		#define UNIQUE_FUNCTION<%0...%1> %0088%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 88
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (89)
 		#define UNIQUE_FUNCTION<%0...%1> %0089%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 89
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (90)
 		#define UNIQUE_FUNCTION<%0...%1> %0090%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_000_to_099_CALLED;
 #elseif UNIQUE_SYMBOL < 100
 	#if UNIQUE_SYMBOL == 90
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (91)
 		#define UNIQUE_FUNCTION<%0...%1> %0091%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 91
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (92)
 		#define UNIQUE_FUNCTION<%0...%1> %0092%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 92
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (93)
 		#define UNIQUE_FUNCTION<%0...%1> %0093%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 93
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (94)
 		#define UNIQUE_FUNCTION<%0...%1> %0094%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 94
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (95)
 		#define UNIQUE_FUNCTION<%0...%1> %0095%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 95
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (96)
 		#define UNIQUE_FUNCTION<%0...%1> %0096%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 96
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (97)
 		#define UNIQUE_FUNCTION<%0...%1> %0097%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 97
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (98)
 		#define UNIQUE_FUNCTION<%0...%1> %0098%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 98
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (99)
 		#define UNIQUE_FUNCTION<%0...%1> %0099%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 99
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (100)
 		#define UNIQUE_FUNCTION<%0...%1> %0100%1
 		#endinput

--- a/YSI_Internal/y_unique/_100_to_199.inc
+++ b/YSI_Internal/y_unique/_100_to_199.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #if UNIQUE_SYMBOL < 110
 	#if UNIQUE_SYMBOL == 100
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (101)
 		#define UNIQUE_FUNCTION<%0...%1> %0101%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 101
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (102)
 		#define UNIQUE_FUNCTION<%0...%1> %0102%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 102
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (103)
 		#define UNIQUE_FUNCTION<%0...%1> %0103%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 103
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (104)
 		#define UNIQUE_FUNCTION<%0...%1> %0104%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 104
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (105)
 		#define UNIQUE_FUNCTION<%0...%1> %0105%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 105
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (106)
 		#define UNIQUE_FUNCTION<%0...%1> %0106%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 106
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (107)
 		#define UNIQUE_FUNCTION<%0...%1> %0107%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 107
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (108)
 		#define UNIQUE_FUNCTION<%0...%1> %0108%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 108
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (109)
 		#define UNIQUE_FUNCTION<%0...%1> %0109%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 109
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (110)
 		#define UNIQUE_FUNCTION<%0...%1> %0110%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 120
 	#if UNIQUE_SYMBOL == 110
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (111)
 		#define UNIQUE_FUNCTION<%0...%1> %0111%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 111
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (112)
 		#define UNIQUE_FUNCTION<%0...%1> %0112%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 112
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (113)
 		#define UNIQUE_FUNCTION<%0...%1> %0113%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 113
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (114)
 		#define UNIQUE_FUNCTION<%0...%1> %0114%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 114
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (115)
 		#define UNIQUE_FUNCTION<%0...%1> %0115%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 115
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (116)
 		#define UNIQUE_FUNCTION<%0...%1> %0116%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 116
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (117)
 		#define UNIQUE_FUNCTION<%0...%1> %0117%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 117
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (118)
 		#define UNIQUE_FUNCTION<%0...%1> %0118%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 118
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (119)
 		#define UNIQUE_FUNCTION<%0...%1> %0119%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 119
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (120)
 		#define UNIQUE_FUNCTION<%0...%1> %0120%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 130
 	#if UNIQUE_SYMBOL == 120
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (121)
 		#define UNIQUE_FUNCTION<%0...%1> %0121%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 121
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (122)
 		#define UNIQUE_FUNCTION<%0...%1> %0122%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 122
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (123)
 		#define UNIQUE_FUNCTION<%0...%1> %0123%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 123
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (124)
 		#define UNIQUE_FUNCTION<%0...%1> %0124%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 124
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (125)
 		#define UNIQUE_FUNCTION<%0...%1> %0125%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 125
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (126)
 		#define UNIQUE_FUNCTION<%0...%1> %0126%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 126
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (127)
 		#define UNIQUE_FUNCTION<%0...%1> %0127%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 127
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (128)
 		#define UNIQUE_FUNCTION<%0...%1> %0128%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 128
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (129)
 		#define UNIQUE_FUNCTION<%0...%1> %0129%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 129
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (130)
 		#define UNIQUE_FUNCTION<%0...%1> %0130%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 140
 	#if UNIQUE_SYMBOL == 130
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (131)
 		#define UNIQUE_FUNCTION<%0...%1> %0131%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 131
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (132)
 		#define UNIQUE_FUNCTION<%0...%1> %0132%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 132
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (133)
 		#define UNIQUE_FUNCTION<%0...%1> %0133%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 133
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (134)
 		#define UNIQUE_FUNCTION<%0...%1> %0134%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 134
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (135)
 		#define UNIQUE_FUNCTION<%0...%1> %0135%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 135
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (136)
 		#define UNIQUE_FUNCTION<%0...%1> %0136%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 136
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (137)
 		#define UNIQUE_FUNCTION<%0...%1> %0137%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 137
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (138)
 		#define UNIQUE_FUNCTION<%0...%1> %0138%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 138
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (139)
 		#define UNIQUE_FUNCTION<%0...%1> %0139%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 139
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (140)
 		#define UNIQUE_FUNCTION<%0...%1> %0140%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 150
 	#if UNIQUE_SYMBOL == 140
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (141)
 		#define UNIQUE_FUNCTION<%0...%1> %0141%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 141
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (142)
 		#define UNIQUE_FUNCTION<%0...%1> %0142%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 142
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (143)
 		#define UNIQUE_FUNCTION<%0...%1> %0143%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 143
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (144)
 		#define UNIQUE_FUNCTION<%0...%1> %0144%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 144
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (145)
 		#define UNIQUE_FUNCTION<%0...%1> %0145%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 145
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (146)
 		#define UNIQUE_FUNCTION<%0...%1> %0146%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 146
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (147)
 		#define UNIQUE_FUNCTION<%0...%1> %0147%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 147
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (148)
 		#define UNIQUE_FUNCTION<%0...%1> %0148%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 148
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (149)
 		#define UNIQUE_FUNCTION<%0...%1> %0149%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 149
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (150)
 		#define UNIQUE_FUNCTION<%0...%1> %0150%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 160
 	#if UNIQUE_SYMBOL == 150
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (151)
 		#define UNIQUE_FUNCTION<%0...%1> %0151%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 151
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (152)
 		#define UNIQUE_FUNCTION<%0...%1> %0152%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 152
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (153)
 		#define UNIQUE_FUNCTION<%0...%1> %0153%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 153
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (154)
 		#define UNIQUE_FUNCTION<%0...%1> %0154%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 154
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (155)
 		#define UNIQUE_FUNCTION<%0...%1> %0155%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 155
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (156)
 		#define UNIQUE_FUNCTION<%0...%1> %0156%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 156
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (157)
 		#define UNIQUE_FUNCTION<%0...%1> %0157%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 157
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (158)
 		#define UNIQUE_FUNCTION<%0...%1> %0158%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 158
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (159)
 		#define UNIQUE_FUNCTION<%0...%1> %0159%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 159
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (160)
 		#define UNIQUE_FUNCTION<%0...%1> %0160%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 170
 	#if UNIQUE_SYMBOL == 160
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (161)
 		#define UNIQUE_FUNCTION<%0...%1> %0161%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 161
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (162)
 		#define UNIQUE_FUNCTION<%0...%1> %0162%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 162
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (163)
 		#define UNIQUE_FUNCTION<%0...%1> %0163%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 163
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (164)
 		#define UNIQUE_FUNCTION<%0...%1> %0164%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 164
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (165)
 		#define UNIQUE_FUNCTION<%0...%1> %0165%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 165
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (166)
 		#define UNIQUE_FUNCTION<%0...%1> %0166%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 166
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (167)
 		#define UNIQUE_FUNCTION<%0...%1> %0167%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 167
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (168)
 		#define UNIQUE_FUNCTION<%0...%1> %0168%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 168
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (169)
 		#define UNIQUE_FUNCTION<%0...%1> %0169%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 169
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (170)
 		#define UNIQUE_FUNCTION<%0...%1> %0170%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 180
 	#if UNIQUE_SYMBOL == 170
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (171)
 		#define UNIQUE_FUNCTION<%0...%1> %0171%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 171
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (172)
 		#define UNIQUE_FUNCTION<%0...%1> %0172%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 172
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (173)
 		#define UNIQUE_FUNCTION<%0...%1> %0173%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 173
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (174)
 		#define UNIQUE_FUNCTION<%0...%1> %0174%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 174
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (175)
 		#define UNIQUE_FUNCTION<%0...%1> %0175%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 175
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (176)
 		#define UNIQUE_FUNCTION<%0...%1> %0176%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 176
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (177)
 		#define UNIQUE_FUNCTION<%0...%1> %0177%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 177
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (178)
 		#define UNIQUE_FUNCTION<%0...%1> %0178%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 178
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (179)
 		#define UNIQUE_FUNCTION<%0...%1> %0179%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 179
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (180)
 		#define UNIQUE_FUNCTION<%0...%1> %0180%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 190
 	#if UNIQUE_SYMBOL == 180
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (181)
 		#define UNIQUE_FUNCTION<%0...%1> %0181%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 181
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (182)
 		#define UNIQUE_FUNCTION<%0...%1> %0182%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 182
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (183)
 		#define UNIQUE_FUNCTION<%0...%1> %0183%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 183
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (184)
 		#define UNIQUE_FUNCTION<%0...%1> %0184%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 184
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (185)
 		#define UNIQUE_FUNCTION<%0...%1> %0185%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 185
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (186)
 		#define UNIQUE_FUNCTION<%0...%1> %0186%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 186
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (187)
 		#define UNIQUE_FUNCTION<%0...%1> %0187%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 187
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (188)
 		#define UNIQUE_FUNCTION<%0...%1> %0188%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 188
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (189)
 		#define UNIQUE_FUNCTION<%0...%1> %0189%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 189
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (190)
 		#define UNIQUE_FUNCTION<%0...%1> %0190%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_100_to_199_CALLED;
 #elseif UNIQUE_SYMBOL < 200
 	#if UNIQUE_SYMBOL == 190
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (191)
 		#define UNIQUE_FUNCTION<%0...%1> %0191%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 191
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (192)
 		#define UNIQUE_FUNCTION<%0...%1> %0192%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 192
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (193)
 		#define UNIQUE_FUNCTION<%0...%1> %0193%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 193
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (194)
 		#define UNIQUE_FUNCTION<%0...%1> %0194%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 194
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (195)
 		#define UNIQUE_FUNCTION<%0...%1> %0195%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 195
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (196)
 		#define UNIQUE_FUNCTION<%0...%1> %0196%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 196
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (197)
 		#define UNIQUE_FUNCTION<%0...%1> %0197%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 197
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (198)
 		#define UNIQUE_FUNCTION<%0...%1> %0198%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 198
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (199)
 		#define UNIQUE_FUNCTION<%0...%1> %0199%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 199
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (200)
 		#define UNIQUE_FUNCTION<%0...%1> %0200%1
 		#endinput

--- a/YSI_Internal/y_unique/_200_to_299.inc
+++ b/YSI_Internal/y_unique/_200_to_299.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #if UNIQUE_SYMBOL < 210
 	#if UNIQUE_SYMBOL == 200
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (201)
 		#define UNIQUE_FUNCTION<%0...%1> %0201%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 201
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (202)
 		#define UNIQUE_FUNCTION<%0...%1> %0202%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 202
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (203)
 		#define UNIQUE_FUNCTION<%0...%1> %0203%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 203
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (204)
 		#define UNIQUE_FUNCTION<%0...%1> %0204%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 204
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (205)
 		#define UNIQUE_FUNCTION<%0...%1> %0205%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 205
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (206)
 		#define UNIQUE_FUNCTION<%0...%1> %0206%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 206
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (207)
 		#define UNIQUE_FUNCTION<%0...%1> %0207%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 207
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (208)
 		#define UNIQUE_FUNCTION<%0...%1> %0208%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 208
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (209)
 		#define UNIQUE_FUNCTION<%0...%1> %0209%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 209
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (210)
 		#define UNIQUE_FUNCTION<%0...%1> %0210%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 220
 	#if UNIQUE_SYMBOL == 210
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (211)
 		#define UNIQUE_FUNCTION<%0...%1> %0211%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 211
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (212)
 		#define UNIQUE_FUNCTION<%0...%1> %0212%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 212
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (213)
 		#define UNIQUE_FUNCTION<%0...%1> %0213%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 213
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (214)
 		#define UNIQUE_FUNCTION<%0...%1> %0214%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 214
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (215)
 		#define UNIQUE_FUNCTION<%0...%1> %0215%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 215
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (216)
 		#define UNIQUE_FUNCTION<%0...%1> %0216%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 216
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (217)
 		#define UNIQUE_FUNCTION<%0...%1> %0217%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 217
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (218)
 		#define UNIQUE_FUNCTION<%0...%1> %0218%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 218
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (219)
 		#define UNIQUE_FUNCTION<%0...%1> %0219%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 219
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (220)
 		#define UNIQUE_FUNCTION<%0...%1> %0220%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 230
 	#if UNIQUE_SYMBOL == 220
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (221)
 		#define UNIQUE_FUNCTION<%0...%1> %0221%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 221
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (222)
 		#define UNIQUE_FUNCTION<%0...%1> %0222%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 222
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (223)
 		#define UNIQUE_FUNCTION<%0...%1> %0223%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 223
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (224)
 		#define UNIQUE_FUNCTION<%0...%1> %0224%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 224
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (225)
 		#define UNIQUE_FUNCTION<%0...%1> %0225%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 225
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (226)
 		#define UNIQUE_FUNCTION<%0...%1> %0226%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 226
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (227)
 		#define UNIQUE_FUNCTION<%0...%1> %0227%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 227
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (228)
 		#define UNIQUE_FUNCTION<%0...%1> %0228%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 228
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (229)
 		#define UNIQUE_FUNCTION<%0...%1> %0229%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 229
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (230)
 		#define UNIQUE_FUNCTION<%0...%1> %0230%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 240
 	#if UNIQUE_SYMBOL == 230
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (231)
 		#define UNIQUE_FUNCTION<%0...%1> %0231%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 231
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (232)
 		#define UNIQUE_FUNCTION<%0...%1> %0232%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 232
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (233)
 		#define UNIQUE_FUNCTION<%0...%1> %0233%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 233
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (234)
 		#define UNIQUE_FUNCTION<%0...%1> %0234%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 234
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (235)
 		#define UNIQUE_FUNCTION<%0...%1> %0235%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 235
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (236)
 		#define UNIQUE_FUNCTION<%0...%1> %0236%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 236
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (237)
 		#define UNIQUE_FUNCTION<%0...%1> %0237%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 237
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (238)
 		#define UNIQUE_FUNCTION<%0...%1> %0238%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 238
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (239)
 		#define UNIQUE_FUNCTION<%0...%1> %0239%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 239
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (240)
 		#define UNIQUE_FUNCTION<%0...%1> %0240%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 250
 	#if UNIQUE_SYMBOL == 240
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (241)
 		#define UNIQUE_FUNCTION<%0...%1> %0241%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 241
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (242)
 		#define UNIQUE_FUNCTION<%0...%1> %0242%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 242
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (243)
 		#define UNIQUE_FUNCTION<%0...%1> %0243%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 243
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (244)
 		#define UNIQUE_FUNCTION<%0...%1> %0244%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 244
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (245)
 		#define UNIQUE_FUNCTION<%0...%1> %0245%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 245
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (246)
 		#define UNIQUE_FUNCTION<%0...%1> %0246%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 246
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (247)
 		#define UNIQUE_FUNCTION<%0...%1> %0247%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 247
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (248)
 		#define UNIQUE_FUNCTION<%0...%1> %0248%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 248
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (249)
 		#define UNIQUE_FUNCTION<%0...%1> %0249%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 249
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (250)
 		#define UNIQUE_FUNCTION<%0...%1> %0250%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 260
 	#if UNIQUE_SYMBOL == 250
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (251)
 		#define UNIQUE_FUNCTION<%0...%1> %0251%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 251
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (252)
 		#define UNIQUE_FUNCTION<%0...%1> %0252%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 252
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (253)
 		#define UNIQUE_FUNCTION<%0...%1> %0253%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 253
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (254)
 		#define UNIQUE_FUNCTION<%0...%1> %0254%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 254
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (255)
 		#define UNIQUE_FUNCTION<%0...%1> %0255%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 255
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (256)
 		#define UNIQUE_FUNCTION<%0...%1> %0256%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 256
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (257)
 		#define UNIQUE_FUNCTION<%0...%1> %0257%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 257
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (258)
 		#define UNIQUE_FUNCTION<%0...%1> %0258%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 258
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (259)
 		#define UNIQUE_FUNCTION<%0...%1> %0259%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 259
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (260)
 		#define UNIQUE_FUNCTION<%0...%1> %0260%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 270
 	#if UNIQUE_SYMBOL == 260
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (261)
 		#define UNIQUE_FUNCTION<%0...%1> %0261%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 261
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (262)
 		#define UNIQUE_FUNCTION<%0...%1> %0262%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 262
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (263)
 		#define UNIQUE_FUNCTION<%0...%1> %0263%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 263
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (264)
 		#define UNIQUE_FUNCTION<%0...%1> %0264%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 264
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (265)
 		#define UNIQUE_FUNCTION<%0...%1> %0265%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 265
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (266)
 		#define UNIQUE_FUNCTION<%0...%1> %0266%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 266
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (267)
 		#define UNIQUE_FUNCTION<%0...%1> %0267%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 267
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (268)
 		#define UNIQUE_FUNCTION<%0...%1> %0268%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 268
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (269)
 		#define UNIQUE_FUNCTION<%0...%1> %0269%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 269
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (270)
 		#define UNIQUE_FUNCTION<%0...%1> %0270%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 280
 	#if UNIQUE_SYMBOL == 270
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (271)
 		#define UNIQUE_FUNCTION<%0...%1> %0271%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 271
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (272)
 		#define UNIQUE_FUNCTION<%0...%1> %0272%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 272
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (273)
 		#define UNIQUE_FUNCTION<%0...%1> %0273%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 273
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (274)
 		#define UNIQUE_FUNCTION<%0...%1> %0274%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 274
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (275)
 		#define UNIQUE_FUNCTION<%0...%1> %0275%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 275
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (276)
 		#define UNIQUE_FUNCTION<%0...%1> %0276%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 276
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (277)
 		#define UNIQUE_FUNCTION<%0...%1> %0277%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 277
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (278)
 		#define UNIQUE_FUNCTION<%0...%1> %0278%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 278
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (279)
 		#define UNIQUE_FUNCTION<%0...%1> %0279%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 279
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (280)
 		#define UNIQUE_FUNCTION<%0...%1> %0280%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 290
 	#if UNIQUE_SYMBOL == 280
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (281)
 		#define UNIQUE_FUNCTION<%0...%1> %0281%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 281
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (282)
 		#define UNIQUE_FUNCTION<%0...%1> %0282%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 282
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (283)
 		#define UNIQUE_FUNCTION<%0...%1> %0283%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 283
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (284)
 		#define UNIQUE_FUNCTION<%0...%1> %0284%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 284
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (285)
 		#define UNIQUE_FUNCTION<%0...%1> %0285%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 285
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (286)
 		#define UNIQUE_FUNCTION<%0...%1> %0286%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 286
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (287)
 		#define UNIQUE_FUNCTION<%0...%1> %0287%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 287
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (288)
 		#define UNIQUE_FUNCTION<%0...%1> %0288%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 288
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (289)
 		#define UNIQUE_FUNCTION<%0...%1> %0289%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 289
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (290)
 		#define UNIQUE_FUNCTION<%0...%1> %0290%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_200_to_299_CALLED;
 #elseif UNIQUE_SYMBOL < 300
 	#if UNIQUE_SYMBOL == 290
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (291)
 		#define UNIQUE_FUNCTION<%0...%1> %0291%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 291
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (292)
 		#define UNIQUE_FUNCTION<%0...%1> %0292%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 292
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (293)
 		#define UNIQUE_FUNCTION<%0...%1> %0293%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 293
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (294)
 		#define UNIQUE_FUNCTION<%0...%1> %0294%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 294
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (295)
 		#define UNIQUE_FUNCTION<%0...%1> %0295%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 295
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (296)
 		#define UNIQUE_FUNCTION<%0...%1> %0296%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 296
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (297)
 		#define UNIQUE_FUNCTION<%0...%1> %0297%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 297
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (298)
 		#define UNIQUE_FUNCTION<%0...%1> %0298%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 298
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (299)
 		#define UNIQUE_FUNCTION<%0...%1> %0299%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 299
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (300)
 		#define UNIQUE_FUNCTION<%0...%1> %0300%1
 		#endinput

--- a/YSI_Internal/y_unique/_300_to_399.inc
+++ b/YSI_Internal/y_unique/_300_to_399.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #if UNIQUE_SYMBOL < 310
 	#if UNIQUE_SYMBOL == 300
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (301)
 		#define UNIQUE_FUNCTION<%0...%1> %0301%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 301
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (302)
 		#define UNIQUE_FUNCTION<%0...%1> %0302%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 302
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (303)
 		#define UNIQUE_FUNCTION<%0...%1> %0303%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 303
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (304)
 		#define UNIQUE_FUNCTION<%0...%1> %0304%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 304
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (305)
 		#define UNIQUE_FUNCTION<%0...%1> %0305%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 305
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (306)
 		#define UNIQUE_FUNCTION<%0...%1> %0306%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 306
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (307)
 		#define UNIQUE_FUNCTION<%0...%1> %0307%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 307
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (308)
 		#define UNIQUE_FUNCTION<%0...%1> %0308%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 308
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (309)
 		#define UNIQUE_FUNCTION<%0...%1> %0309%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 309
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (310)
 		#define UNIQUE_FUNCTION<%0...%1> %0310%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 320
 	#if UNIQUE_SYMBOL == 310
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (311)
 		#define UNIQUE_FUNCTION<%0...%1> %0311%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 311
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (312)
 		#define UNIQUE_FUNCTION<%0...%1> %0312%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 312
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (313)
 		#define UNIQUE_FUNCTION<%0...%1> %0313%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 313
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (314)
 		#define UNIQUE_FUNCTION<%0...%1> %0314%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 314
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (315)
 		#define UNIQUE_FUNCTION<%0...%1> %0315%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 315
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (316)
 		#define UNIQUE_FUNCTION<%0...%1> %0316%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 316
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (317)
 		#define UNIQUE_FUNCTION<%0...%1> %0317%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 317
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (318)
 		#define UNIQUE_FUNCTION<%0...%1> %0318%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 318
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (319)
 		#define UNIQUE_FUNCTION<%0...%1> %0319%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 319
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (320)
 		#define UNIQUE_FUNCTION<%0...%1> %0320%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 330
 	#if UNIQUE_SYMBOL == 320
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (321)
 		#define UNIQUE_FUNCTION<%0...%1> %0321%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 321
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (322)
 		#define UNIQUE_FUNCTION<%0...%1> %0322%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 322
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (323)
 		#define UNIQUE_FUNCTION<%0...%1> %0323%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 323
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (324)
 		#define UNIQUE_FUNCTION<%0...%1> %0324%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 324
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (325)
 		#define UNIQUE_FUNCTION<%0...%1> %0325%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 325
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (326)
 		#define UNIQUE_FUNCTION<%0...%1> %0326%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 326
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (327)
 		#define UNIQUE_FUNCTION<%0...%1> %0327%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 327
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (328)
 		#define UNIQUE_FUNCTION<%0...%1> %0328%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 328
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (329)
 		#define UNIQUE_FUNCTION<%0...%1> %0329%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 329
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (330)
 		#define UNIQUE_FUNCTION<%0...%1> %0330%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 340
 	#if UNIQUE_SYMBOL == 330
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (331)
 		#define UNIQUE_FUNCTION<%0...%1> %0331%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 331
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (332)
 		#define UNIQUE_FUNCTION<%0...%1> %0332%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 332
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (333)
 		#define UNIQUE_FUNCTION<%0...%1> %0333%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 333
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (334)
 		#define UNIQUE_FUNCTION<%0...%1> %0334%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 334
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (335)
 		#define UNIQUE_FUNCTION<%0...%1> %0335%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 335
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (336)
 		#define UNIQUE_FUNCTION<%0...%1> %0336%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 336
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (337)
 		#define UNIQUE_FUNCTION<%0...%1> %0337%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 337
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (338)
 		#define UNIQUE_FUNCTION<%0...%1> %0338%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 338
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (339)
 		#define UNIQUE_FUNCTION<%0...%1> %0339%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 339
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (340)
 		#define UNIQUE_FUNCTION<%0...%1> %0340%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 350
 	#if UNIQUE_SYMBOL == 340
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (341)
 		#define UNIQUE_FUNCTION<%0...%1> %0341%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 341
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (342)
 		#define UNIQUE_FUNCTION<%0...%1> %0342%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 342
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (343)
 		#define UNIQUE_FUNCTION<%0...%1> %0343%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 343
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (344)
 		#define UNIQUE_FUNCTION<%0...%1> %0344%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 344
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (345)
 		#define UNIQUE_FUNCTION<%0...%1> %0345%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 345
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (346)
 		#define UNIQUE_FUNCTION<%0...%1> %0346%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 346
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (347)
 		#define UNIQUE_FUNCTION<%0...%1> %0347%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 347
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (348)
 		#define UNIQUE_FUNCTION<%0...%1> %0348%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 348
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (349)
 		#define UNIQUE_FUNCTION<%0...%1> %0349%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 349
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (350)
 		#define UNIQUE_FUNCTION<%0...%1> %0350%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 360
 	#if UNIQUE_SYMBOL == 350
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (351)
 		#define UNIQUE_FUNCTION<%0...%1> %0351%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 351
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (352)
 		#define UNIQUE_FUNCTION<%0...%1> %0352%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 352
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (353)
 		#define UNIQUE_FUNCTION<%0...%1> %0353%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 353
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (354)
 		#define UNIQUE_FUNCTION<%0...%1> %0354%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 354
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (355)
 		#define UNIQUE_FUNCTION<%0...%1> %0355%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 355
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (356)
 		#define UNIQUE_FUNCTION<%0...%1> %0356%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 356
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (357)
 		#define UNIQUE_FUNCTION<%0...%1> %0357%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 357
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (358)
 		#define UNIQUE_FUNCTION<%0...%1> %0358%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 358
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (359)
 		#define UNIQUE_FUNCTION<%0...%1> %0359%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 359
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (360)
 		#define UNIQUE_FUNCTION<%0...%1> %0360%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 370
 	#if UNIQUE_SYMBOL == 360
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (361)
 		#define UNIQUE_FUNCTION<%0...%1> %0361%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 361
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (362)
 		#define UNIQUE_FUNCTION<%0...%1> %0362%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 362
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (363)
 		#define UNIQUE_FUNCTION<%0...%1> %0363%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 363
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (364)
 		#define UNIQUE_FUNCTION<%0...%1> %0364%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 364
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (365)
 		#define UNIQUE_FUNCTION<%0...%1> %0365%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 365
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (366)
 		#define UNIQUE_FUNCTION<%0...%1> %0366%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 366
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (367)
 		#define UNIQUE_FUNCTION<%0...%1> %0367%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 367
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (368)
 		#define UNIQUE_FUNCTION<%0...%1> %0368%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 368
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (369)
 		#define UNIQUE_FUNCTION<%0...%1> %0369%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 369
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (370)
 		#define UNIQUE_FUNCTION<%0...%1> %0370%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 380
 	#if UNIQUE_SYMBOL == 370
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (371)
 		#define UNIQUE_FUNCTION<%0...%1> %0371%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 371
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (372)
 		#define UNIQUE_FUNCTION<%0...%1> %0372%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 372
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (373)
 		#define UNIQUE_FUNCTION<%0...%1> %0373%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 373
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (374)
 		#define UNIQUE_FUNCTION<%0...%1> %0374%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 374
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (375)
 		#define UNIQUE_FUNCTION<%0...%1> %0375%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 375
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (376)
 		#define UNIQUE_FUNCTION<%0...%1> %0376%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 376
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (377)
 		#define UNIQUE_FUNCTION<%0...%1> %0377%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 377
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (378)
 		#define UNIQUE_FUNCTION<%0...%1> %0378%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 378
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (379)
 		#define UNIQUE_FUNCTION<%0...%1> %0379%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 379
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (380)
 		#define UNIQUE_FUNCTION<%0...%1> %0380%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 390
 	#if UNIQUE_SYMBOL == 380
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (381)
 		#define UNIQUE_FUNCTION<%0...%1> %0381%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 381
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (382)
 		#define UNIQUE_FUNCTION<%0...%1> %0382%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 382
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (383)
 		#define UNIQUE_FUNCTION<%0...%1> %0383%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 383
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (384)
 		#define UNIQUE_FUNCTION<%0...%1> %0384%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 384
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (385)
 		#define UNIQUE_FUNCTION<%0...%1> %0385%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 385
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (386)
 		#define UNIQUE_FUNCTION<%0...%1> %0386%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 386
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (387)
 		#define UNIQUE_FUNCTION<%0...%1> %0387%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 387
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (388)
 		#define UNIQUE_FUNCTION<%0...%1> %0388%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 388
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (389)
 		#define UNIQUE_FUNCTION<%0...%1> %0389%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 389
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (390)
 		#define UNIQUE_FUNCTION<%0...%1> %0390%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_300_to_399_CALLED;
 #elseif UNIQUE_SYMBOL < 400
 	#if UNIQUE_SYMBOL == 390
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (391)
 		#define UNIQUE_FUNCTION<%0...%1> %0391%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 391
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (392)
 		#define UNIQUE_FUNCTION<%0...%1> %0392%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 392
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (393)
 		#define UNIQUE_FUNCTION<%0...%1> %0393%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 393
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (394)
 		#define UNIQUE_FUNCTION<%0...%1> %0394%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 394
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (395)
 		#define UNIQUE_FUNCTION<%0...%1> %0395%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 395
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (396)
 		#define UNIQUE_FUNCTION<%0...%1> %0396%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 396
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (397)
 		#define UNIQUE_FUNCTION<%0...%1> %0397%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 397
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (398)
 		#define UNIQUE_FUNCTION<%0...%1> %0398%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 398
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (399)
 		#define UNIQUE_FUNCTION<%0...%1> %0399%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 399
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (400)
 		#define UNIQUE_FUNCTION<%0...%1> %0400%1
 		#endinput

--- a/YSI_Internal/y_unique/_400_to_499.inc
+++ b/YSI_Internal/y_unique/_400_to_499.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #if UNIQUE_SYMBOL < 410
 	#if UNIQUE_SYMBOL == 400
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (401)
 		#define UNIQUE_FUNCTION<%0...%1> %0401%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 401
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (402)
 		#define UNIQUE_FUNCTION<%0...%1> %0402%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 402
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (403)
 		#define UNIQUE_FUNCTION<%0...%1> %0403%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 403
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (404)
 		#define UNIQUE_FUNCTION<%0...%1> %0404%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 404
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (405)
 		#define UNIQUE_FUNCTION<%0...%1> %0405%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 405
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (406)
 		#define UNIQUE_FUNCTION<%0...%1> %0406%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 406
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (407)
 		#define UNIQUE_FUNCTION<%0...%1> %0407%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 407
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (408)
 		#define UNIQUE_FUNCTION<%0...%1> %0408%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 408
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (409)
 		#define UNIQUE_FUNCTION<%0...%1> %0409%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 409
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (410)
 		#define UNIQUE_FUNCTION<%0...%1> %0410%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 420
 	#if UNIQUE_SYMBOL == 410
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (411)
 		#define UNIQUE_FUNCTION<%0...%1> %0411%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 411
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (412)
 		#define UNIQUE_FUNCTION<%0...%1> %0412%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 412
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (413)
 		#define UNIQUE_FUNCTION<%0...%1> %0413%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 413
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (414)
 		#define UNIQUE_FUNCTION<%0...%1> %0414%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 414
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (415)
 		#define UNIQUE_FUNCTION<%0...%1> %0415%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 415
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (416)
 		#define UNIQUE_FUNCTION<%0...%1> %0416%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 416
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (417)
 		#define UNIQUE_FUNCTION<%0...%1> %0417%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 417
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (418)
 		#define UNIQUE_FUNCTION<%0...%1> %0418%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 418
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (419)
 		#define UNIQUE_FUNCTION<%0...%1> %0419%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 419
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (420)
 		#define UNIQUE_FUNCTION<%0...%1> %0420%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 430
 	#if UNIQUE_SYMBOL == 420
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (421)
 		#define UNIQUE_FUNCTION<%0...%1> %0421%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 421
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (422)
 		#define UNIQUE_FUNCTION<%0...%1> %0422%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 422
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (423)
 		#define UNIQUE_FUNCTION<%0...%1> %0423%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 423
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (424)
 		#define UNIQUE_FUNCTION<%0...%1> %0424%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 424
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (425)
 		#define UNIQUE_FUNCTION<%0...%1> %0425%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 425
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (426)
 		#define UNIQUE_FUNCTION<%0...%1> %0426%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 426
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (427)
 		#define UNIQUE_FUNCTION<%0...%1> %0427%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 427
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (428)
 		#define UNIQUE_FUNCTION<%0...%1> %0428%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 428
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (429)
 		#define UNIQUE_FUNCTION<%0...%1> %0429%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 429
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (430)
 		#define UNIQUE_FUNCTION<%0...%1> %0430%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 440
 	#if UNIQUE_SYMBOL == 430
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (431)
 		#define UNIQUE_FUNCTION<%0...%1> %0431%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 431
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (432)
 		#define UNIQUE_FUNCTION<%0...%1> %0432%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 432
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (433)
 		#define UNIQUE_FUNCTION<%0...%1> %0433%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 433
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (434)
 		#define UNIQUE_FUNCTION<%0...%1> %0434%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 434
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (435)
 		#define UNIQUE_FUNCTION<%0...%1> %0435%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 435
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (436)
 		#define UNIQUE_FUNCTION<%0...%1> %0436%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 436
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (437)
 		#define UNIQUE_FUNCTION<%0...%1> %0437%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 437
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (438)
 		#define UNIQUE_FUNCTION<%0...%1> %0438%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 438
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (439)
 		#define UNIQUE_FUNCTION<%0...%1> %0439%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 439
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (440)
 		#define UNIQUE_FUNCTION<%0...%1> %0440%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 450
 	#if UNIQUE_SYMBOL == 440
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (441)
 		#define UNIQUE_FUNCTION<%0...%1> %0441%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 441
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (442)
 		#define UNIQUE_FUNCTION<%0...%1> %0442%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 442
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (443)
 		#define UNIQUE_FUNCTION<%0...%1> %0443%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 443
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (444)
 		#define UNIQUE_FUNCTION<%0...%1> %0444%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 444
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (445)
 		#define UNIQUE_FUNCTION<%0...%1> %0445%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 445
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (446)
 		#define UNIQUE_FUNCTION<%0...%1> %0446%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 446
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (447)
 		#define UNIQUE_FUNCTION<%0...%1> %0447%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 447
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (448)
 		#define UNIQUE_FUNCTION<%0...%1> %0448%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 448
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (449)
 		#define UNIQUE_FUNCTION<%0...%1> %0449%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 449
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (450)
 		#define UNIQUE_FUNCTION<%0...%1> %0450%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 460
 	#if UNIQUE_SYMBOL == 450
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (451)
 		#define UNIQUE_FUNCTION<%0...%1> %0451%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 451
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (452)
 		#define UNIQUE_FUNCTION<%0...%1> %0452%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 452
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (453)
 		#define UNIQUE_FUNCTION<%0...%1> %0453%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 453
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (454)
 		#define UNIQUE_FUNCTION<%0...%1> %0454%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 454
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (455)
 		#define UNIQUE_FUNCTION<%0...%1> %0455%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 455
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (456)
 		#define UNIQUE_FUNCTION<%0...%1> %0456%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 456
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (457)
 		#define UNIQUE_FUNCTION<%0...%1> %0457%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 457
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (458)
 		#define UNIQUE_FUNCTION<%0...%1> %0458%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 458
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (459)
 		#define UNIQUE_FUNCTION<%0...%1> %0459%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 459
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (460)
 		#define UNIQUE_FUNCTION<%0...%1> %0460%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 470
 	#if UNIQUE_SYMBOL == 460
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (461)
 		#define UNIQUE_FUNCTION<%0...%1> %0461%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 461
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (462)
 		#define UNIQUE_FUNCTION<%0...%1> %0462%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 462
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (463)
 		#define UNIQUE_FUNCTION<%0...%1> %0463%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 463
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (464)
 		#define UNIQUE_FUNCTION<%0...%1> %0464%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 464
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (465)
 		#define UNIQUE_FUNCTION<%0...%1> %0465%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 465
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (466)
 		#define UNIQUE_FUNCTION<%0...%1> %0466%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 466
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (467)
 		#define UNIQUE_FUNCTION<%0...%1> %0467%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 467
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (468)
 		#define UNIQUE_FUNCTION<%0...%1> %0468%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 468
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (469)
 		#define UNIQUE_FUNCTION<%0...%1> %0469%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 469
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (470)
 		#define UNIQUE_FUNCTION<%0...%1> %0470%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 480
 	#if UNIQUE_SYMBOL == 470
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (471)
 		#define UNIQUE_FUNCTION<%0...%1> %0471%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 471
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (472)
 		#define UNIQUE_FUNCTION<%0...%1> %0472%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 472
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (473)
 		#define UNIQUE_FUNCTION<%0...%1> %0473%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 473
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (474)
 		#define UNIQUE_FUNCTION<%0...%1> %0474%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 474
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (475)
 		#define UNIQUE_FUNCTION<%0...%1> %0475%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 475
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (476)
 		#define UNIQUE_FUNCTION<%0...%1> %0476%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 476
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (477)
 		#define UNIQUE_FUNCTION<%0...%1> %0477%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 477
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (478)
 		#define UNIQUE_FUNCTION<%0...%1> %0478%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 478
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (479)
 		#define UNIQUE_FUNCTION<%0...%1> %0479%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 479
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (480)
 		#define UNIQUE_FUNCTION<%0...%1> %0480%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 490
 	#if UNIQUE_SYMBOL == 480
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (481)
 		#define UNIQUE_FUNCTION<%0...%1> %0481%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 481
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (482)
 		#define UNIQUE_FUNCTION<%0...%1> %0482%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 482
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (483)
 		#define UNIQUE_FUNCTION<%0...%1> %0483%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 483
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (484)
 		#define UNIQUE_FUNCTION<%0...%1> %0484%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 484
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (485)
 		#define UNIQUE_FUNCTION<%0...%1> %0485%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 485
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (486)
 		#define UNIQUE_FUNCTION<%0...%1> %0486%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 486
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (487)
 		#define UNIQUE_FUNCTION<%0...%1> %0487%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 487
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (488)
 		#define UNIQUE_FUNCTION<%0...%1> %0488%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 488
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (489)
 		#define UNIQUE_FUNCTION<%0...%1> %0489%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 489
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (490)
 		#define UNIQUE_FUNCTION<%0...%1> %0490%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_400_to_499_CALLED;
 #elseif UNIQUE_SYMBOL < 500
 	#if UNIQUE_SYMBOL == 490
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (491)
 		#define UNIQUE_FUNCTION<%0...%1> %0491%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 491
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (492)
 		#define UNIQUE_FUNCTION<%0...%1> %0492%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 492
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (493)
 		#define UNIQUE_FUNCTION<%0...%1> %0493%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 493
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (494)
 		#define UNIQUE_FUNCTION<%0...%1> %0494%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 494
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (495)
 		#define UNIQUE_FUNCTION<%0...%1> %0495%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 495
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (496)
 		#define UNIQUE_FUNCTION<%0...%1> %0496%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 496
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (497)
 		#define UNIQUE_FUNCTION<%0...%1> %0497%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 497
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (498)
 		#define UNIQUE_FUNCTION<%0...%1> %0498%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 498
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (499)
 		#define UNIQUE_FUNCTION<%0...%1> %0499%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 499
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (500)
 		#define UNIQUE_FUNCTION<%0...%1> %0500%1
 		#endinput

--- a/YSI_Internal/y_unique/_500_to_599.inc
+++ b/YSI_Internal/y_unique/_500_to_599.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #if UNIQUE_SYMBOL < 510
 	#if UNIQUE_SYMBOL == 500
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (501)
 		#define UNIQUE_FUNCTION<%0...%1> %0501%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 501
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (502)
 		#define UNIQUE_FUNCTION<%0...%1> %0502%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 502
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (503)
 		#define UNIQUE_FUNCTION<%0...%1> %0503%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 503
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (504)
 		#define UNIQUE_FUNCTION<%0...%1> %0504%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 504
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (505)
 		#define UNIQUE_FUNCTION<%0...%1> %0505%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 505
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (506)
 		#define UNIQUE_FUNCTION<%0...%1> %0506%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 506
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (507)
 		#define UNIQUE_FUNCTION<%0...%1> %0507%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 507
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (508)
 		#define UNIQUE_FUNCTION<%0...%1> %0508%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 508
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (509)
 		#define UNIQUE_FUNCTION<%0...%1> %0509%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 509
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (510)
 		#define UNIQUE_FUNCTION<%0...%1> %0510%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 520
 	#if UNIQUE_SYMBOL == 510
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (511)
 		#define UNIQUE_FUNCTION<%0...%1> %0511%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 511
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (512)
 		#define UNIQUE_FUNCTION<%0...%1> %0512%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 512
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (513)
 		#define UNIQUE_FUNCTION<%0...%1> %0513%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 513
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (514)
 		#define UNIQUE_FUNCTION<%0...%1> %0514%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 514
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (515)
 		#define UNIQUE_FUNCTION<%0...%1> %0515%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 515
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (516)
 		#define UNIQUE_FUNCTION<%0...%1> %0516%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 516
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (517)
 		#define UNIQUE_FUNCTION<%0...%1> %0517%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 517
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (518)
 		#define UNIQUE_FUNCTION<%0...%1> %0518%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 518
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (519)
 		#define UNIQUE_FUNCTION<%0...%1> %0519%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 519
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (520)
 		#define UNIQUE_FUNCTION<%0...%1> %0520%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 530
 	#if UNIQUE_SYMBOL == 520
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (521)
 		#define UNIQUE_FUNCTION<%0...%1> %0521%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 521
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (522)
 		#define UNIQUE_FUNCTION<%0...%1> %0522%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 522
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (523)
 		#define UNIQUE_FUNCTION<%0...%1> %0523%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 523
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (524)
 		#define UNIQUE_FUNCTION<%0...%1> %0524%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 524
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (525)
 		#define UNIQUE_FUNCTION<%0...%1> %0525%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 525
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (526)
 		#define UNIQUE_FUNCTION<%0...%1> %0526%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 526
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (527)
 		#define UNIQUE_FUNCTION<%0...%1> %0527%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 527
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (528)
 		#define UNIQUE_FUNCTION<%0...%1> %0528%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 528
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (529)
 		#define UNIQUE_FUNCTION<%0...%1> %0529%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 529
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (530)
 		#define UNIQUE_FUNCTION<%0...%1> %0530%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 540
 	#if UNIQUE_SYMBOL == 530
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (531)
 		#define UNIQUE_FUNCTION<%0...%1> %0531%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 531
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (532)
 		#define UNIQUE_FUNCTION<%0...%1> %0532%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 532
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (533)
 		#define UNIQUE_FUNCTION<%0...%1> %0533%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 533
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (534)
 		#define UNIQUE_FUNCTION<%0...%1> %0534%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 534
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (535)
 		#define UNIQUE_FUNCTION<%0...%1> %0535%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 535
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (536)
 		#define UNIQUE_FUNCTION<%0...%1> %0536%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 536
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (537)
 		#define UNIQUE_FUNCTION<%0...%1> %0537%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 537
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (538)
 		#define UNIQUE_FUNCTION<%0...%1> %0538%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 538
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (539)
 		#define UNIQUE_FUNCTION<%0...%1> %0539%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 539
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (540)
 		#define UNIQUE_FUNCTION<%0...%1> %0540%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 550
 	#if UNIQUE_SYMBOL == 540
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (541)
 		#define UNIQUE_FUNCTION<%0...%1> %0541%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 541
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (542)
 		#define UNIQUE_FUNCTION<%0...%1> %0542%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 542
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (543)
 		#define UNIQUE_FUNCTION<%0...%1> %0543%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 543
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (544)
 		#define UNIQUE_FUNCTION<%0...%1> %0544%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 544
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (545)
 		#define UNIQUE_FUNCTION<%0...%1> %0545%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 545
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (546)
 		#define UNIQUE_FUNCTION<%0...%1> %0546%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 546
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (547)
 		#define UNIQUE_FUNCTION<%0...%1> %0547%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 547
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (548)
 		#define UNIQUE_FUNCTION<%0...%1> %0548%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 548
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (549)
 		#define UNIQUE_FUNCTION<%0...%1> %0549%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 549
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (550)
 		#define UNIQUE_FUNCTION<%0...%1> %0550%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 560
 	#if UNIQUE_SYMBOL == 550
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (551)
 		#define UNIQUE_FUNCTION<%0...%1> %0551%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 551
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (552)
 		#define UNIQUE_FUNCTION<%0...%1> %0552%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 552
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (553)
 		#define UNIQUE_FUNCTION<%0...%1> %0553%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 553
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (554)
 		#define UNIQUE_FUNCTION<%0...%1> %0554%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 554
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (555)
 		#define UNIQUE_FUNCTION<%0...%1> %0555%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 555
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (556)
 		#define UNIQUE_FUNCTION<%0...%1> %0556%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 556
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (557)
 		#define UNIQUE_FUNCTION<%0...%1> %0557%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 557
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (558)
 		#define UNIQUE_FUNCTION<%0...%1> %0558%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 558
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (559)
 		#define UNIQUE_FUNCTION<%0...%1> %0559%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 559
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (560)
 		#define UNIQUE_FUNCTION<%0...%1> %0560%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 570
 	#if UNIQUE_SYMBOL == 560
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (561)
 		#define UNIQUE_FUNCTION<%0...%1> %0561%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 561
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (562)
 		#define UNIQUE_FUNCTION<%0...%1> %0562%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 562
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (563)
 		#define UNIQUE_FUNCTION<%0...%1> %0563%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 563
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (564)
 		#define UNIQUE_FUNCTION<%0...%1> %0564%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 564
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (565)
 		#define UNIQUE_FUNCTION<%0...%1> %0565%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 565
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (566)
 		#define UNIQUE_FUNCTION<%0...%1> %0566%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 566
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (567)
 		#define UNIQUE_FUNCTION<%0...%1> %0567%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 567
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (568)
 		#define UNIQUE_FUNCTION<%0...%1> %0568%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 568
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (569)
 		#define UNIQUE_FUNCTION<%0...%1> %0569%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 569
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (570)
 		#define UNIQUE_FUNCTION<%0...%1> %0570%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 580
 	#if UNIQUE_SYMBOL == 570
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (571)
 		#define UNIQUE_FUNCTION<%0...%1> %0571%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 571
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (572)
 		#define UNIQUE_FUNCTION<%0...%1> %0572%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 572
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (573)
 		#define UNIQUE_FUNCTION<%0...%1> %0573%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 573
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (574)
 		#define UNIQUE_FUNCTION<%0...%1> %0574%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 574
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (575)
 		#define UNIQUE_FUNCTION<%0...%1> %0575%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 575
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (576)
 		#define UNIQUE_FUNCTION<%0...%1> %0576%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 576
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (577)
 		#define UNIQUE_FUNCTION<%0...%1> %0577%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 577
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (578)
 		#define UNIQUE_FUNCTION<%0...%1> %0578%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 578
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (579)
 		#define UNIQUE_FUNCTION<%0...%1> %0579%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 579
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (580)
 		#define UNIQUE_FUNCTION<%0...%1> %0580%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 590
 	#if UNIQUE_SYMBOL == 580
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (581)
 		#define UNIQUE_FUNCTION<%0...%1> %0581%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 581
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (582)
 		#define UNIQUE_FUNCTION<%0...%1> %0582%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 582
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (583)
 		#define UNIQUE_FUNCTION<%0...%1> %0583%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 583
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (584)
 		#define UNIQUE_FUNCTION<%0...%1> %0584%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 584
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (585)
 		#define UNIQUE_FUNCTION<%0...%1> %0585%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 585
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (586)
 		#define UNIQUE_FUNCTION<%0...%1> %0586%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 586
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (587)
 		#define UNIQUE_FUNCTION<%0...%1> %0587%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 587
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (588)
 		#define UNIQUE_FUNCTION<%0...%1> %0588%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 588
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (589)
 		#define UNIQUE_FUNCTION<%0...%1> %0589%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 589
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (590)
 		#define UNIQUE_FUNCTION<%0...%1> %0590%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_500_to_599_CALLED;
 #elseif UNIQUE_SYMBOL < 600
 	#if UNIQUE_SYMBOL == 590
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (591)
 		#define UNIQUE_FUNCTION<%0...%1> %0591%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 591
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (592)
 		#define UNIQUE_FUNCTION<%0...%1> %0592%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 592
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (593)
 		#define UNIQUE_FUNCTION<%0...%1> %0593%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 593
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (594)
 		#define UNIQUE_FUNCTION<%0...%1> %0594%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 594
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (595)
 		#define UNIQUE_FUNCTION<%0...%1> %0595%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 595
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (596)
 		#define UNIQUE_FUNCTION<%0...%1> %0596%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 596
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (597)
 		#define UNIQUE_FUNCTION<%0...%1> %0597%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 597
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (598)
 		#define UNIQUE_FUNCTION<%0...%1> %0598%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 598
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (599)
 		#define UNIQUE_FUNCTION<%0...%1> %0599%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 599
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (600)
 		#define UNIQUE_FUNCTION<%0...%1> %0600%1
 		#endinput

--- a/YSI_Internal/y_unique/_600_to_699.inc
+++ b/YSI_Internal/y_unique/_600_to_699.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #if UNIQUE_SYMBOL < 610
 	#if UNIQUE_SYMBOL == 600
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (601)
 		#define UNIQUE_FUNCTION<%0...%1> %0601%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 601
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (602)
 		#define UNIQUE_FUNCTION<%0...%1> %0602%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 602
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (603)
 		#define UNIQUE_FUNCTION<%0...%1> %0603%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 603
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (604)
 		#define UNIQUE_FUNCTION<%0...%1> %0604%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 604
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (605)
 		#define UNIQUE_FUNCTION<%0...%1> %0605%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 605
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (606)
 		#define UNIQUE_FUNCTION<%0...%1> %0606%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 606
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (607)
 		#define UNIQUE_FUNCTION<%0...%1> %0607%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 607
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (608)
 		#define UNIQUE_FUNCTION<%0...%1> %0608%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 608
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (609)
 		#define UNIQUE_FUNCTION<%0...%1> %0609%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 609
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (610)
 		#define UNIQUE_FUNCTION<%0...%1> %0610%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 620
 	#if UNIQUE_SYMBOL == 610
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (611)
 		#define UNIQUE_FUNCTION<%0...%1> %0611%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 611
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (612)
 		#define UNIQUE_FUNCTION<%0...%1> %0612%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 612
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (613)
 		#define UNIQUE_FUNCTION<%0...%1> %0613%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 613
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (614)
 		#define UNIQUE_FUNCTION<%0...%1> %0614%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 614
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (615)
 		#define UNIQUE_FUNCTION<%0...%1> %0615%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 615
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (616)
 		#define UNIQUE_FUNCTION<%0...%1> %0616%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 616
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (617)
 		#define UNIQUE_FUNCTION<%0...%1> %0617%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 617
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (618)
 		#define UNIQUE_FUNCTION<%0...%1> %0618%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 618
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (619)
 		#define UNIQUE_FUNCTION<%0...%1> %0619%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 619
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (620)
 		#define UNIQUE_FUNCTION<%0...%1> %0620%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 630
 	#if UNIQUE_SYMBOL == 620
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (621)
 		#define UNIQUE_FUNCTION<%0...%1> %0621%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 621
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (622)
 		#define UNIQUE_FUNCTION<%0...%1> %0622%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 622
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (623)
 		#define UNIQUE_FUNCTION<%0...%1> %0623%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 623
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (624)
 		#define UNIQUE_FUNCTION<%0...%1> %0624%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 624
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (625)
 		#define UNIQUE_FUNCTION<%0...%1> %0625%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 625
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (626)
 		#define UNIQUE_FUNCTION<%0...%1> %0626%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 626
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (627)
 		#define UNIQUE_FUNCTION<%0...%1> %0627%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 627
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (628)
 		#define UNIQUE_FUNCTION<%0...%1> %0628%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 628
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (629)
 		#define UNIQUE_FUNCTION<%0...%1> %0629%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 629
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (630)
 		#define UNIQUE_FUNCTION<%0...%1> %0630%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 640
 	#if UNIQUE_SYMBOL == 630
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (631)
 		#define UNIQUE_FUNCTION<%0...%1> %0631%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 631
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (632)
 		#define UNIQUE_FUNCTION<%0...%1> %0632%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 632
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (633)
 		#define UNIQUE_FUNCTION<%0...%1> %0633%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 633
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (634)
 		#define UNIQUE_FUNCTION<%0...%1> %0634%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 634
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (635)
 		#define UNIQUE_FUNCTION<%0...%1> %0635%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 635
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (636)
 		#define UNIQUE_FUNCTION<%0...%1> %0636%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 636
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (637)
 		#define UNIQUE_FUNCTION<%0...%1> %0637%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 637
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (638)
 		#define UNIQUE_FUNCTION<%0...%1> %0638%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 638
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (639)
 		#define UNIQUE_FUNCTION<%0...%1> %0639%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 639
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (640)
 		#define UNIQUE_FUNCTION<%0...%1> %0640%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 650
 	#if UNIQUE_SYMBOL == 640
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (641)
 		#define UNIQUE_FUNCTION<%0...%1> %0641%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 641
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (642)
 		#define UNIQUE_FUNCTION<%0...%1> %0642%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 642
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (643)
 		#define UNIQUE_FUNCTION<%0...%1> %0643%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 643
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (644)
 		#define UNIQUE_FUNCTION<%0...%1> %0644%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 644
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (645)
 		#define UNIQUE_FUNCTION<%0...%1> %0645%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 645
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (646)
 		#define UNIQUE_FUNCTION<%0...%1> %0646%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 646
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (647)
 		#define UNIQUE_FUNCTION<%0...%1> %0647%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 647
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (648)
 		#define UNIQUE_FUNCTION<%0...%1> %0648%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 648
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (649)
 		#define UNIQUE_FUNCTION<%0...%1> %0649%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 649
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (650)
 		#define UNIQUE_FUNCTION<%0...%1> %0650%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 660
 	#if UNIQUE_SYMBOL == 650
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (651)
 		#define UNIQUE_FUNCTION<%0...%1> %0651%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 651
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (652)
 		#define UNIQUE_FUNCTION<%0...%1> %0652%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 652
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (653)
 		#define UNIQUE_FUNCTION<%0...%1> %0653%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 653
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (654)
 		#define UNIQUE_FUNCTION<%0...%1> %0654%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 654
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (655)
 		#define UNIQUE_FUNCTION<%0...%1> %0655%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 655
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (656)
 		#define UNIQUE_FUNCTION<%0...%1> %0656%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 656
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (657)
 		#define UNIQUE_FUNCTION<%0...%1> %0657%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 657
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (658)
 		#define UNIQUE_FUNCTION<%0...%1> %0658%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 658
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (659)
 		#define UNIQUE_FUNCTION<%0...%1> %0659%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 659
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (660)
 		#define UNIQUE_FUNCTION<%0...%1> %0660%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 670
 	#if UNIQUE_SYMBOL == 660
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (661)
 		#define UNIQUE_FUNCTION<%0...%1> %0661%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 661
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (662)
 		#define UNIQUE_FUNCTION<%0...%1> %0662%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 662
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (663)
 		#define UNIQUE_FUNCTION<%0...%1> %0663%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 663
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (664)
 		#define UNIQUE_FUNCTION<%0...%1> %0664%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 664
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (665)
 		#define UNIQUE_FUNCTION<%0...%1> %0665%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 665
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (666)
 		#define UNIQUE_FUNCTION<%0...%1> %0666%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 666
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (667)
 		#define UNIQUE_FUNCTION<%0...%1> %0667%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 667
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (668)
 		#define UNIQUE_FUNCTION<%0...%1> %0668%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 668
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (669)
 		#define UNIQUE_FUNCTION<%0...%1> %0669%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 669
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (670)
 		#define UNIQUE_FUNCTION<%0...%1> %0670%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 680
 	#if UNIQUE_SYMBOL == 670
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (671)
 		#define UNIQUE_FUNCTION<%0...%1> %0671%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 671
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (672)
 		#define UNIQUE_FUNCTION<%0...%1> %0672%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 672
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (673)
 		#define UNIQUE_FUNCTION<%0...%1> %0673%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 673
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (674)
 		#define UNIQUE_FUNCTION<%0...%1> %0674%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 674
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (675)
 		#define UNIQUE_FUNCTION<%0...%1> %0675%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 675
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (676)
 		#define UNIQUE_FUNCTION<%0...%1> %0676%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 676
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (677)
 		#define UNIQUE_FUNCTION<%0...%1> %0677%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 677
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (678)
 		#define UNIQUE_FUNCTION<%0...%1> %0678%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 678
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (679)
 		#define UNIQUE_FUNCTION<%0...%1> %0679%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 679
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (680)
 		#define UNIQUE_FUNCTION<%0...%1> %0680%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 690
 	#if UNIQUE_SYMBOL == 680
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (681)
 		#define UNIQUE_FUNCTION<%0...%1> %0681%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 681
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (682)
 		#define UNIQUE_FUNCTION<%0...%1> %0682%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 682
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (683)
 		#define UNIQUE_FUNCTION<%0...%1> %0683%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 683
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (684)
 		#define UNIQUE_FUNCTION<%0...%1> %0684%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 684
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (685)
 		#define UNIQUE_FUNCTION<%0...%1> %0685%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 685
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (686)
 		#define UNIQUE_FUNCTION<%0...%1> %0686%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 686
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (687)
 		#define UNIQUE_FUNCTION<%0...%1> %0687%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 687
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (688)
 		#define UNIQUE_FUNCTION<%0...%1> %0688%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 688
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (689)
 		#define UNIQUE_FUNCTION<%0...%1> %0689%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 689
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (690)
 		#define UNIQUE_FUNCTION<%0...%1> %0690%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_600_to_699_CALLED;
 #elseif UNIQUE_SYMBOL < 700
 	#if UNIQUE_SYMBOL == 690
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (691)
 		#define UNIQUE_FUNCTION<%0...%1> %0691%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 691
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (692)
 		#define UNIQUE_FUNCTION<%0...%1> %0692%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 692
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (693)
 		#define UNIQUE_FUNCTION<%0...%1> %0693%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 693
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (694)
 		#define UNIQUE_FUNCTION<%0...%1> %0694%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 694
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (695)
 		#define UNIQUE_FUNCTION<%0...%1> %0695%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 695
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (696)
 		#define UNIQUE_FUNCTION<%0...%1> %0696%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 696
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (697)
 		#define UNIQUE_FUNCTION<%0...%1> %0697%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 697
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (698)
 		#define UNIQUE_FUNCTION<%0...%1> %0698%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 698
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (699)
 		#define UNIQUE_FUNCTION<%0...%1> %0699%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 699
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (700)
 		#define UNIQUE_FUNCTION<%0...%1> %0700%1
 		#endinput

--- a/YSI_Internal/y_unique/_700_to_799.inc
+++ b/YSI_Internal/y_unique/_700_to_799.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #if UNIQUE_SYMBOL < 710
 	#if UNIQUE_SYMBOL == 700
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (701)
 		#define UNIQUE_FUNCTION<%0...%1> %0701%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 701
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (702)
 		#define UNIQUE_FUNCTION<%0...%1> %0702%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 702
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (703)
 		#define UNIQUE_FUNCTION<%0...%1> %0703%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 703
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (704)
 		#define UNIQUE_FUNCTION<%0...%1> %0704%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 704
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (705)
 		#define UNIQUE_FUNCTION<%0...%1> %0705%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 705
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (706)
 		#define UNIQUE_FUNCTION<%0...%1> %0706%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 706
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (707)
 		#define UNIQUE_FUNCTION<%0...%1> %0707%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 707
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (708)
 		#define UNIQUE_FUNCTION<%0...%1> %0708%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 708
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (709)
 		#define UNIQUE_FUNCTION<%0...%1> %0709%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 709
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (710)
 		#define UNIQUE_FUNCTION<%0...%1> %0710%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 720
 	#if UNIQUE_SYMBOL == 710
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (711)
 		#define UNIQUE_FUNCTION<%0...%1> %0711%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 711
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (712)
 		#define UNIQUE_FUNCTION<%0...%1> %0712%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 712
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (713)
 		#define UNIQUE_FUNCTION<%0...%1> %0713%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 713
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (714)
 		#define UNIQUE_FUNCTION<%0...%1> %0714%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 714
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (715)
 		#define UNIQUE_FUNCTION<%0...%1> %0715%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 715
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (716)
 		#define UNIQUE_FUNCTION<%0...%1> %0716%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 716
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (717)
 		#define UNIQUE_FUNCTION<%0...%1> %0717%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 717
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (718)
 		#define UNIQUE_FUNCTION<%0...%1> %0718%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 718
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (719)
 		#define UNIQUE_FUNCTION<%0...%1> %0719%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 719
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (720)
 		#define UNIQUE_FUNCTION<%0...%1> %0720%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 730
 	#if UNIQUE_SYMBOL == 720
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (721)
 		#define UNIQUE_FUNCTION<%0...%1> %0721%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 721
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (722)
 		#define UNIQUE_FUNCTION<%0...%1> %0722%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 722
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (723)
 		#define UNIQUE_FUNCTION<%0...%1> %0723%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 723
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (724)
 		#define UNIQUE_FUNCTION<%0...%1> %0724%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 724
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (725)
 		#define UNIQUE_FUNCTION<%0...%1> %0725%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 725
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (726)
 		#define UNIQUE_FUNCTION<%0...%1> %0726%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 726
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (727)
 		#define UNIQUE_FUNCTION<%0...%1> %0727%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 727
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (728)
 		#define UNIQUE_FUNCTION<%0...%1> %0728%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 728
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (729)
 		#define UNIQUE_FUNCTION<%0...%1> %0729%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 729
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (730)
 		#define UNIQUE_FUNCTION<%0...%1> %0730%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 740
 	#if UNIQUE_SYMBOL == 730
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (731)
 		#define UNIQUE_FUNCTION<%0...%1> %0731%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 731
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (732)
 		#define UNIQUE_FUNCTION<%0...%1> %0732%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 732
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (733)
 		#define UNIQUE_FUNCTION<%0...%1> %0733%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 733
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (734)
 		#define UNIQUE_FUNCTION<%0...%1> %0734%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 734
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (735)
 		#define UNIQUE_FUNCTION<%0...%1> %0735%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 735
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (736)
 		#define UNIQUE_FUNCTION<%0...%1> %0736%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 736
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (737)
 		#define UNIQUE_FUNCTION<%0...%1> %0737%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 737
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (738)
 		#define UNIQUE_FUNCTION<%0...%1> %0738%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 738
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (739)
 		#define UNIQUE_FUNCTION<%0...%1> %0739%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 739
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (740)
 		#define UNIQUE_FUNCTION<%0...%1> %0740%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 750
 	#if UNIQUE_SYMBOL == 740
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (741)
 		#define UNIQUE_FUNCTION<%0...%1> %0741%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 741
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (742)
 		#define UNIQUE_FUNCTION<%0...%1> %0742%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 742
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (743)
 		#define UNIQUE_FUNCTION<%0...%1> %0743%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 743
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (744)
 		#define UNIQUE_FUNCTION<%0...%1> %0744%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 744
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (745)
 		#define UNIQUE_FUNCTION<%0...%1> %0745%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 745
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (746)
 		#define UNIQUE_FUNCTION<%0...%1> %0746%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 746
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (747)
 		#define UNIQUE_FUNCTION<%0...%1> %0747%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 747
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (748)
 		#define UNIQUE_FUNCTION<%0...%1> %0748%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 748
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (749)
 		#define UNIQUE_FUNCTION<%0...%1> %0749%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 749
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (750)
 		#define UNIQUE_FUNCTION<%0...%1> %0750%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 760
 	#if UNIQUE_SYMBOL == 750
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (751)
 		#define UNIQUE_FUNCTION<%0...%1> %0751%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 751
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (752)
 		#define UNIQUE_FUNCTION<%0...%1> %0752%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 752
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (753)
 		#define UNIQUE_FUNCTION<%0...%1> %0753%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 753
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (754)
 		#define UNIQUE_FUNCTION<%0...%1> %0754%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 754
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (755)
 		#define UNIQUE_FUNCTION<%0...%1> %0755%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 755
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (756)
 		#define UNIQUE_FUNCTION<%0...%1> %0756%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 756
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (757)
 		#define UNIQUE_FUNCTION<%0...%1> %0757%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 757
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (758)
 		#define UNIQUE_FUNCTION<%0...%1> %0758%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 758
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (759)
 		#define UNIQUE_FUNCTION<%0...%1> %0759%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 759
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (760)
 		#define UNIQUE_FUNCTION<%0...%1> %0760%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 770
 	#if UNIQUE_SYMBOL == 760
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (761)
 		#define UNIQUE_FUNCTION<%0...%1> %0761%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 761
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (762)
 		#define UNIQUE_FUNCTION<%0...%1> %0762%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 762
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (763)
 		#define UNIQUE_FUNCTION<%0...%1> %0763%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 763
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (764)
 		#define UNIQUE_FUNCTION<%0...%1> %0764%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 764
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (765)
 		#define UNIQUE_FUNCTION<%0...%1> %0765%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 765
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (766)
 		#define UNIQUE_FUNCTION<%0...%1> %0766%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 766
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (767)
 		#define UNIQUE_FUNCTION<%0...%1> %0767%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 767
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (768)
 		#define UNIQUE_FUNCTION<%0...%1> %0768%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 768
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (769)
 		#define UNIQUE_FUNCTION<%0...%1> %0769%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 769
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (770)
 		#define UNIQUE_FUNCTION<%0...%1> %0770%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 780
 	#if UNIQUE_SYMBOL == 770
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (771)
 		#define UNIQUE_FUNCTION<%0...%1> %0771%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 771
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (772)
 		#define UNIQUE_FUNCTION<%0...%1> %0772%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 772
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (773)
 		#define UNIQUE_FUNCTION<%0...%1> %0773%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 773
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (774)
 		#define UNIQUE_FUNCTION<%0...%1> %0774%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 774
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (775)
 		#define UNIQUE_FUNCTION<%0...%1> %0775%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 775
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (776)
 		#define UNIQUE_FUNCTION<%0...%1> %0776%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 776
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (777)
 		#define UNIQUE_FUNCTION<%0...%1> %0777%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 777
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (778)
 		#define UNIQUE_FUNCTION<%0...%1> %0778%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 778
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (779)
 		#define UNIQUE_FUNCTION<%0...%1> %0779%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 779
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (780)
 		#define UNIQUE_FUNCTION<%0...%1> %0780%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 790
 	#if UNIQUE_SYMBOL == 780
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (781)
 		#define UNIQUE_FUNCTION<%0...%1> %0781%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 781
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (782)
 		#define UNIQUE_FUNCTION<%0...%1> %0782%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 782
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (783)
 		#define UNIQUE_FUNCTION<%0...%1> %0783%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 783
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (784)
 		#define UNIQUE_FUNCTION<%0...%1> %0784%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 784
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (785)
 		#define UNIQUE_FUNCTION<%0...%1> %0785%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 785
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (786)
 		#define UNIQUE_FUNCTION<%0...%1> %0786%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 786
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (787)
 		#define UNIQUE_FUNCTION<%0...%1> %0787%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 787
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (788)
 		#define UNIQUE_FUNCTION<%0...%1> %0788%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 788
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (789)
 		#define UNIQUE_FUNCTION<%0...%1> %0789%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 789
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (790)
 		#define UNIQUE_FUNCTION<%0...%1> %0790%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_700_to_799_CALLED;
 #elseif UNIQUE_SYMBOL < 800
 	#if UNIQUE_SYMBOL == 790
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (791)
 		#define UNIQUE_FUNCTION<%0...%1> %0791%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 791
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (792)
 		#define UNIQUE_FUNCTION<%0...%1> %0792%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 792
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (793)
 		#define UNIQUE_FUNCTION<%0...%1> %0793%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 793
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (794)
 		#define UNIQUE_FUNCTION<%0...%1> %0794%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 794
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (795)
 		#define UNIQUE_FUNCTION<%0...%1> %0795%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 795
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (796)
 		#define UNIQUE_FUNCTION<%0...%1> %0796%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 796
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (797)
 		#define UNIQUE_FUNCTION<%0...%1> %0797%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 797
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (798)
 		#define UNIQUE_FUNCTION<%0...%1> %0798%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 798
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (799)
 		#define UNIQUE_FUNCTION<%0...%1> %0799%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 799
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (800)
 		#define UNIQUE_FUNCTION<%0...%1> %0800%1
 		#endinput

--- a/YSI_Internal/y_unique/_800_to_899.inc
+++ b/YSI_Internal/y_unique/_800_to_899.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #if UNIQUE_SYMBOL < 810
 	#if UNIQUE_SYMBOL == 800
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (801)
 		#define UNIQUE_FUNCTION<%0...%1> %0801%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 801
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (802)
 		#define UNIQUE_FUNCTION<%0...%1> %0802%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 802
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (803)
 		#define UNIQUE_FUNCTION<%0...%1> %0803%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 803
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (804)
 		#define UNIQUE_FUNCTION<%0...%1> %0804%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 804
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (805)
 		#define UNIQUE_FUNCTION<%0...%1> %0805%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 805
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (806)
 		#define UNIQUE_FUNCTION<%0...%1> %0806%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 806
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (807)
 		#define UNIQUE_FUNCTION<%0...%1> %0807%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 807
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (808)
 		#define UNIQUE_FUNCTION<%0...%1> %0808%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 808
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (809)
 		#define UNIQUE_FUNCTION<%0...%1> %0809%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 809
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (810)
 		#define UNIQUE_FUNCTION<%0...%1> %0810%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 820
 	#if UNIQUE_SYMBOL == 810
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (811)
 		#define UNIQUE_FUNCTION<%0...%1> %0811%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 811
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (812)
 		#define UNIQUE_FUNCTION<%0...%1> %0812%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 812
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (813)
 		#define UNIQUE_FUNCTION<%0...%1> %0813%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 813
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (814)
 		#define UNIQUE_FUNCTION<%0...%1> %0814%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 814
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (815)
 		#define UNIQUE_FUNCTION<%0...%1> %0815%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 815
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (816)
 		#define UNIQUE_FUNCTION<%0...%1> %0816%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 816
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (817)
 		#define UNIQUE_FUNCTION<%0...%1> %0817%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 817
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (818)
 		#define UNIQUE_FUNCTION<%0...%1> %0818%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 818
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (819)
 		#define UNIQUE_FUNCTION<%0...%1> %0819%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 819
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (820)
 		#define UNIQUE_FUNCTION<%0...%1> %0820%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 830
 	#if UNIQUE_SYMBOL == 820
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (821)
 		#define UNIQUE_FUNCTION<%0...%1> %0821%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 821
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (822)
 		#define UNIQUE_FUNCTION<%0...%1> %0822%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 822
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (823)
 		#define UNIQUE_FUNCTION<%0...%1> %0823%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 823
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (824)
 		#define UNIQUE_FUNCTION<%0...%1> %0824%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 824
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (825)
 		#define UNIQUE_FUNCTION<%0...%1> %0825%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 825
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (826)
 		#define UNIQUE_FUNCTION<%0...%1> %0826%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 826
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (827)
 		#define UNIQUE_FUNCTION<%0...%1> %0827%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 827
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (828)
 		#define UNIQUE_FUNCTION<%0...%1> %0828%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 828
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (829)
 		#define UNIQUE_FUNCTION<%0...%1> %0829%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 829
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (830)
 		#define UNIQUE_FUNCTION<%0...%1> %0830%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 840
 	#if UNIQUE_SYMBOL == 830
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (831)
 		#define UNIQUE_FUNCTION<%0...%1> %0831%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 831
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (832)
 		#define UNIQUE_FUNCTION<%0...%1> %0832%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 832
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (833)
 		#define UNIQUE_FUNCTION<%0...%1> %0833%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 833
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (834)
 		#define UNIQUE_FUNCTION<%0...%1> %0834%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 834
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (835)
 		#define UNIQUE_FUNCTION<%0...%1> %0835%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 835
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (836)
 		#define UNIQUE_FUNCTION<%0...%1> %0836%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 836
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (837)
 		#define UNIQUE_FUNCTION<%0...%1> %0837%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 837
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (838)
 		#define UNIQUE_FUNCTION<%0...%1> %0838%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 838
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (839)
 		#define UNIQUE_FUNCTION<%0...%1> %0839%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 839
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (840)
 		#define UNIQUE_FUNCTION<%0...%1> %0840%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 850
 	#if UNIQUE_SYMBOL == 840
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (841)
 		#define UNIQUE_FUNCTION<%0...%1> %0841%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 841
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (842)
 		#define UNIQUE_FUNCTION<%0...%1> %0842%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 842
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (843)
 		#define UNIQUE_FUNCTION<%0...%1> %0843%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 843
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (844)
 		#define UNIQUE_FUNCTION<%0...%1> %0844%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 844
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (845)
 		#define UNIQUE_FUNCTION<%0...%1> %0845%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 845
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (846)
 		#define UNIQUE_FUNCTION<%0...%1> %0846%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 846
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (847)
 		#define UNIQUE_FUNCTION<%0...%1> %0847%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 847
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (848)
 		#define UNIQUE_FUNCTION<%0...%1> %0848%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 848
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (849)
 		#define UNIQUE_FUNCTION<%0...%1> %0849%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 849
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (850)
 		#define UNIQUE_FUNCTION<%0...%1> %0850%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 860
 	#if UNIQUE_SYMBOL == 850
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (851)
 		#define UNIQUE_FUNCTION<%0...%1> %0851%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 851
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (852)
 		#define UNIQUE_FUNCTION<%0...%1> %0852%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 852
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (853)
 		#define UNIQUE_FUNCTION<%0...%1> %0853%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 853
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (854)
 		#define UNIQUE_FUNCTION<%0...%1> %0854%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 854
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (855)
 		#define UNIQUE_FUNCTION<%0...%1> %0855%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 855
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (856)
 		#define UNIQUE_FUNCTION<%0...%1> %0856%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 856
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (857)
 		#define UNIQUE_FUNCTION<%0...%1> %0857%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 857
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (858)
 		#define UNIQUE_FUNCTION<%0...%1> %0858%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 858
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (859)
 		#define UNIQUE_FUNCTION<%0...%1> %0859%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 859
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (860)
 		#define UNIQUE_FUNCTION<%0...%1> %0860%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 870
 	#if UNIQUE_SYMBOL == 860
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (861)
 		#define UNIQUE_FUNCTION<%0...%1> %0861%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 861
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (862)
 		#define UNIQUE_FUNCTION<%0...%1> %0862%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 862
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (863)
 		#define UNIQUE_FUNCTION<%0...%1> %0863%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 863
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (864)
 		#define UNIQUE_FUNCTION<%0...%1> %0864%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 864
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (865)
 		#define UNIQUE_FUNCTION<%0...%1> %0865%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 865
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (866)
 		#define UNIQUE_FUNCTION<%0...%1> %0866%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 866
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (867)
 		#define UNIQUE_FUNCTION<%0...%1> %0867%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 867
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (868)
 		#define UNIQUE_FUNCTION<%0...%1> %0868%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 868
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (869)
 		#define UNIQUE_FUNCTION<%0...%1> %0869%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 869
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (870)
 		#define UNIQUE_FUNCTION<%0...%1> %0870%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 880
 	#if UNIQUE_SYMBOL == 870
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (871)
 		#define UNIQUE_FUNCTION<%0...%1> %0871%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 871
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (872)
 		#define UNIQUE_FUNCTION<%0...%1> %0872%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 872
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (873)
 		#define UNIQUE_FUNCTION<%0...%1> %0873%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 873
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (874)
 		#define UNIQUE_FUNCTION<%0...%1> %0874%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 874
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (875)
 		#define UNIQUE_FUNCTION<%0...%1> %0875%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 875
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (876)
 		#define UNIQUE_FUNCTION<%0...%1> %0876%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 876
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (877)
 		#define UNIQUE_FUNCTION<%0...%1> %0877%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 877
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (878)
 		#define UNIQUE_FUNCTION<%0...%1> %0878%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 878
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (879)
 		#define UNIQUE_FUNCTION<%0...%1> %0879%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 879
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (880)
 		#define UNIQUE_FUNCTION<%0...%1> %0880%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 890
 	#if UNIQUE_SYMBOL == 880
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (881)
 		#define UNIQUE_FUNCTION<%0...%1> %0881%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 881
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (882)
 		#define UNIQUE_FUNCTION<%0...%1> %0882%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 882
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (883)
 		#define UNIQUE_FUNCTION<%0...%1> %0883%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 883
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (884)
 		#define UNIQUE_FUNCTION<%0...%1> %0884%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 884
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (885)
 		#define UNIQUE_FUNCTION<%0...%1> %0885%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 885
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (886)
 		#define UNIQUE_FUNCTION<%0...%1> %0886%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 886
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (887)
 		#define UNIQUE_FUNCTION<%0...%1> %0887%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 887
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (888)
 		#define UNIQUE_FUNCTION<%0...%1> %0888%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 888
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (889)
 		#define UNIQUE_FUNCTION<%0...%1> %0889%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 889
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (890)
 		#define UNIQUE_FUNCTION<%0...%1> %0890%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_800_to_899_CALLED;
 #elseif UNIQUE_SYMBOL < 900
 	#if UNIQUE_SYMBOL == 890
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (891)
 		#define UNIQUE_FUNCTION<%0...%1> %0891%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 891
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (892)
 		#define UNIQUE_FUNCTION<%0...%1> %0892%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 892
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (893)
 		#define UNIQUE_FUNCTION<%0...%1> %0893%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 893
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (894)
 		#define UNIQUE_FUNCTION<%0...%1> %0894%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 894
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (895)
 		#define UNIQUE_FUNCTION<%0...%1> %0895%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 895
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (896)
 		#define UNIQUE_FUNCTION<%0...%1> %0896%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 896
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (897)
 		#define UNIQUE_FUNCTION<%0...%1> %0897%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 897
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (898)
 		#define UNIQUE_FUNCTION<%0...%1> %0898%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 898
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (899)
 		#define UNIQUE_FUNCTION<%0...%1> %0899%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 899
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (900)
 		#define UNIQUE_FUNCTION<%0...%1> %0900%1
 		#endinput

--- a/YSI_Internal/y_unique/_900_to_999.inc
+++ b/YSI_Internal/y_unique/_900_to_999.inc
@@ -7,61 +7,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #if UNIQUE_SYMBOL < 910
 	#if UNIQUE_SYMBOL == 900
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (901)
 		#define UNIQUE_FUNCTION<%0...%1> %0901%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 901
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (902)
 		#define UNIQUE_FUNCTION<%0...%1> %0902%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 902
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (903)
 		#define UNIQUE_FUNCTION<%0...%1> %0903%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 903
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (904)
 		#define UNIQUE_FUNCTION<%0...%1> %0904%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 904
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (905)
 		#define UNIQUE_FUNCTION<%0...%1> %0905%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 905
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (906)
 		#define UNIQUE_FUNCTION<%0...%1> %0906%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 906
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (907)
 		#define UNIQUE_FUNCTION<%0...%1> %0907%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 907
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (908)
 		#define UNIQUE_FUNCTION<%0...%1> %0908%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 908
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (909)
 		#define UNIQUE_FUNCTION<%0...%1> %0909%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 909
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (910)
 		#define UNIQUE_FUNCTION<%0...%1> %0910%1
 		#endinput
@@ -69,61 +59,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 920
 	#if UNIQUE_SYMBOL == 910
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (911)
 		#define UNIQUE_FUNCTION<%0...%1> %0911%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 911
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (912)
 		#define UNIQUE_FUNCTION<%0...%1> %0912%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 912
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (913)
 		#define UNIQUE_FUNCTION<%0...%1> %0913%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 913
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (914)
 		#define UNIQUE_FUNCTION<%0...%1> %0914%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 914
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (915)
 		#define UNIQUE_FUNCTION<%0...%1> %0915%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 915
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (916)
 		#define UNIQUE_FUNCTION<%0...%1> %0916%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 916
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (917)
 		#define UNIQUE_FUNCTION<%0...%1> %0917%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 917
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (918)
 		#define UNIQUE_FUNCTION<%0...%1> %0918%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 918
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (919)
 		#define UNIQUE_FUNCTION<%0...%1> %0919%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 919
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (920)
 		#define UNIQUE_FUNCTION<%0...%1> %0920%1
 		#endinput
@@ -131,61 +111,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 930
 	#if UNIQUE_SYMBOL == 920
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (921)
 		#define UNIQUE_FUNCTION<%0...%1> %0921%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 921
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (922)
 		#define UNIQUE_FUNCTION<%0...%1> %0922%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 922
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (923)
 		#define UNIQUE_FUNCTION<%0...%1> %0923%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 923
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (924)
 		#define UNIQUE_FUNCTION<%0...%1> %0924%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 924
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (925)
 		#define UNIQUE_FUNCTION<%0...%1> %0925%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 925
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (926)
 		#define UNIQUE_FUNCTION<%0...%1> %0926%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 926
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (927)
 		#define UNIQUE_FUNCTION<%0...%1> %0927%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 927
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (928)
 		#define UNIQUE_FUNCTION<%0...%1> %0928%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 928
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (929)
 		#define UNIQUE_FUNCTION<%0...%1> %0929%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 929
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (930)
 		#define UNIQUE_FUNCTION<%0...%1> %0930%1
 		#endinput
@@ -193,61 +163,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 940
 	#if UNIQUE_SYMBOL == 930
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (931)
 		#define UNIQUE_FUNCTION<%0...%1> %0931%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 931
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (932)
 		#define UNIQUE_FUNCTION<%0...%1> %0932%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 932
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (933)
 		#define UNIQUE_FUNCTION<%0...%1> %0933%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 933
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (934)
 		#define UNIQUE_FUNCTION<%0...%1> %0934%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 934
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (935)
 		#define UNIQUE_FUNCTION<%0...%1> %0935%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 935
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (936)
 		#define UNIQUE_FUNCTION<%0...%1> %0936%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 936
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (937)
 		#define UNIQUE_FUNCTION<%0...%1> %0937%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 937
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (938)
 		#define UNIQUE_FUNCTION<%0...%1> %0938%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 938
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (939)
 		#define UNIQUE_FUNCTION<%0...%1> %0939%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 939
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (940)
 		#define UNIQUE_FUNCTION<%0...%1> %0940%1
 		#endinput
@@ -255,61 +215,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 950
 	#if UNIQUE_SYMBOL == 940
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (941)
 		#define UNIQUE_FUNCTION<%0...%1> %0941%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 941
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (942)
 		#define UNIQUE_FUNCTION<%0...%1> %0942%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 942
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (943)
 		#define UNIQUE_FUNCTION<%0...%1> %0943%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 943
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (944)
 		#define UNIQUE_FUNCTION<%0...%1> %0944%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 944
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (945)
 		#define UNIQUE_FUNCTION<%0...%1> %0945%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 945
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (946)
 		#define UNIQUE_FUNCTION<%0...%1> %0946%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 946
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (947)
 		#define UNIQUE_FUNCTION<%0...%1> %0947%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 947
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (948)
 		#define UNIQUE_FUNCTION<%0...%1> %0948%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 948
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (949)
 		#define UNIQUE_FUNCTION<%0...%1> %0949%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 949
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (950)
 		#define UNIQUE_FUNCTION<%0...%1> %0950%1
 		#endinput
@@ -317,61 +267,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 960
 	#if UNIQUE_SYMBOL == 950
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (951)
 		#define UNIQUE_FUNCTION<%0...%1> %0951%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 951
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (952)
 		#define UNIQUE_FUNCTION<%0...%1> %0952%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 952
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (953)
 		#define UNIQUE_FUNCTION<%0...%1> %0953%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 953
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (954)
 		#define UNIQUE_FUNCTION<%0...%1> %0954%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 954
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (955)
 		#define UNIQUE_FUNCTION<%0...%1> %0955%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 955
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (956)
 		#define UNIQUE_FUNCTION<%0...%1> %0956%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 956
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (957)
 		#define UNIQUE_FUNCTION<%0...%1> %0957%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 957
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (958)
 		#define UNIQUE_FUNCTION<%0...%1> %0958%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 958
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (959)
 		#define UNIQUE_FUNCTION<%0...%1> %0959%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 959
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (960)
 		#define UNIQUE_FUNCTION<%0...%1> %0960%1
 		#endinput
@@ -379,61 +319,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 970
 	#if UNIQUE_SYMBOL == 960
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (961)
 		#define UNIQUE_FUNCTION<%0...%1> %0961%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 961
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (962)
 		#define UNIQUE_FUNCTION<%0...%1> %0962%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 962
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (963)
 		#define UNIQUE_FUNCTION<%0...%1> %0963%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 963
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (964)
 		#define UNIQUE_FUNCTION<%0...%1> %0964%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 964
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (965)
 		#define UNIQUE_FUNCTION<%0...%1> %0965%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 965
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (966)
 		#define UNIQUE_FUNCTION<%0...%1> %0966%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 966
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (967)
 		#define UNIQUE_FUNCTION<%0...%1> %0967%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 967
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (968)
 		#define UNIQUE_FUNCTION<%0...%1> %0968%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 968
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (969)
 		#define UNIQUE_FUNCTION<%0...%1> %0969%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 969
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (970)
 		#define UNIQUE_FUNCTION<%0...%1> %0970%1
 		#endinput
@@ -441,61 +371,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 980
 	#if UNIQUE_SYMBOL == 970
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (971)
 		#define UNIQUE_FUNCTION<%0...%1> %0971%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 971
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (972)
 		#define UNIQUE_FUNCTION<%0...%1> %0972%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 972
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (973)
 		#define UNIQUE_FUNCTION<%0...%1> %0973%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 973
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (974)
 		#define UNIQUE_FUNCTION<%0...%1> %0974%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 974
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (975)
 		#define UNIQUE_FUNCTION<%0...%1> %0975%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 975
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (976)
 		#define UNIQUE_FUNCTION<%0...%1> %0976%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 976
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (977)
 		#define UNIQUE_FUNCTION<%0...%1> %0977%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 977
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (978)
 		#define UNIQUE_FUNCTION<%0...%1> %0978%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 978
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (979)
 		#define UNIQUE_FUNCTION<%0...%1> %0979%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 979
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (980)
 		#define UNIQUE_FUNCTION<%0...%1> %0980%1
 		#endinput
@@ -503,61 +423,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 990
 	#if UNIQUE_SYMBOL == 980
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (981)
 		#define UNIQUE_FUNCTION<%0...%1> %0981%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 981
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (982)
 		#define UNIQUE_FUNCTION<%0...%1> %0982%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 982
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (983)
 		#define UNIQUE_FUNCTION<%0...%1> %0983%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 983
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (984)
 		#define UNIQUE_FUNCTION<%0...%1> %0984%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 984
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (985)
 		#define UNIQUE_FUNCTION<%0...%1> %0985%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 985
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (986)
 		#define UNIQUE_FUNCTION<%0...%1> %0986%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 986
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (987)
 		#define UNIQUE_FUNCTION<%0...%1> %0987%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 987
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (988)
 		#define UNIQUE_FUNCTION<%0...%1> %0988%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 988
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (989)
 		#define UNIQUE_FUNCTION<%0...%1> %0989%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 989
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (990)
 		#define UNIQUE_FUNCTION<%0...%1> %0990%1
 		#endinput
@@ -565,61 +475,51 @@ static stock const Y_UNIQUE_900_to_999_CALLED;
 #elseif UNIQUE_SYMBOL < 1000
 	#if UNIQUE_SYMBOL == 990
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (991)
 		#define UNIQUE_FUNCTION<%0...%1> %0991%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 991
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (992)
 		#define UNIQUE_FUNCTION<%0...%1> %0992%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 992
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (993)
 		#define UNIQUE_FUNCTION<%0...%1> %0993%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 993
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (994)
 		#define UNIQUE_FUNCTION<%0...%1> %0994%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 994
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (995)
 		#define UNIQUE_FUNCTION<%0...%1> %0995%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 995
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (996)
 		#define UNIQUE_FUNCTION<%0...%1> %0996%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 996
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (997)
 		#define UNIQUE_FUNCTION<%0...%1> %0997%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 997
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (998)
 		#define UNIQUE_FUNCTION<%0...%1> %0998%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 998
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (999)
 		#define UNIQUE_FUNCTION<%0...%1> %0999%1
 		#endinput
 	#elseif UNIQUE_SYMBOL == 999
 		#undef UNIQUE_SYMBOL
-		#undef UNIQUE_FUNCTION
 		#define UNIQUE_SYMBOL (1000)
 		#define UNIQUE_FUNCTION<%0...%1> %01000%1
 		#endinput

--- a/YSI_Internal/y_writemem.inc
+++ b/YSI_Internal/y_writemem.inc
@@ -101,7 +101,10 @@ Operators:
 #include "..\YSI_Coding\y_hooks"
 #include "..\YSI_Core\y_utils"
 
-#include "..\amx\windows\import_table"
+#tryinclude "..\amx\windows\import_table"
+#tryinclude <amx_assembly\windows\import_table>
+#tryinclude "..\amx_assembly\windows\import_table"
+#tryinclude "..\..\amx_assembly\windows\import_table"
 
 forward WriteMem(addr, value);
 

--- a/YSI_Players/y_groups/impl.inc
+++ b/YSI_Players/y_groups/impl.inc
@@ -764,7 +764,7 @@ remotefunc void:_Group_SetPlayer(p, Bit:g[sizeof RG@], s)
 }
 
 /**--------------------------------------------------------------------------**\
-<summary>Group_SetBalancedArray</summary>
+<summary>_Group_SetBalancedInternal</summary>
 <param name="p">Player to add to the smallest group.</param>
 <param name="Group:gs[]">An array of possible groups.</param>
 <param name="c">The number of USED items in the array.</param>
@@ -772,21 +772,14 @@ remotefunc void:_Group_SetPlayer(p, Bit:g[sizeof RG@], s)
 	The group they have been added to.
 </returns>
 <remarks>
-	Puts a player in whichever of the given groups currently has the least
-	players.
-	
-	Now ONLY takes a list - arrays should use "Group_SetBalancedArray".  As a
-	result, has more error-checking.
-	
 	Chains the call with "Group_SetPlayer" to use its hierarchy code.
 </remarks>
 \**--------------------------------------------------------------------------**/
 
-foreign Group:Group_SetBalancedArray(p,Group:gs[],c);
+foreign Group:_Group_SetBalancedInternal(p,Group:gs[],c);
 
-global Group:Group_SetBalancedArray(p,Group:gs[],c)
+global Group:_Group_SetBalancedInternal(p,Group:gs[],c)
 {
-	if (!(0 <= p < MAX_PLAYERS)) return INVALID_GROUP;
 	// Find which of the listed groups has the least players in.
 	new
 		count = cellmax,
@@ -804,7 +797,7 @@ global Group:Group_SetBalancedArray(p,Group:gs[],c)
 			if (_Group_HasPlayer(g2, p))
 			{
 				// The player is already in this group - just return.
-				return gi;
+				return Group:gi;
 			}
 			else if (cc < count)
 			{
@@ -822,6 +815,29 @@ global Group:Group_SetBalancedArray(p,Group:gs[],c)
 		Group_SetPlayer(id, p, true);
 	}
 	return id;
+}
+
+/**--------------------------------------------------------------------------**\
+<summary>Group_SetBalancedArray</summary>
+<param name="p">Player to add to the smallest group.</param>
+<param name="Group:gs[]">An array of possible groups.</param>
+<param name="c">The number of USED items in the array.</param>
+<returns>
+	The group they have been added to.
+</returns>
+<remarks>
+	Puts a player in whichever of the given groups currently has the least
+	players.
+	
+	Now ONLY takes a list - arrays should use "Group_SetBalancedArray".  As a
+	result, has more error-checking.
+</remarks>
+\**--------------------------------------------------------------------------**/
+
+stock Group:Group_SetBalancedArray(p, Group:gs[], c = sizeof (gs))
+{
+	if (!(0 <= p < MAX_PLAYERS)) return INVALID_GROUP;
+	return _Group_SetBalancedInternal(p, gs, c);
 }
 
 /**--------------------------------------------------------------------------**\

--- a/YSI_Players/y_groups/impl.inc
+++ b/YSI_Players/y_groups/impl.inc
@@ -674,8 +674,6 @@ global void:Group_SetPlayer(Group:g,p,bool:s)
 	if (_Group_IsValid(g) && VALID_PLAYERID(p))
 	{
 		GROUP_FIX(g);
-		//static
-		//	BitArray:n<_MAX_GROUPS_G>;
 		if (s)
 		{
 			if (!_Group_HasPlayer(g, p))
@@ -766,7 +764,7 @@ remotefunc void:_Group_SetPlayer(p, Bit:g[sizeof RG@], s)
 }
 
 /**--------------------------------------------------------------------------**\
-<summary>Group_SetBalancedInternal</summary>
+<summary>Group_SetBalancedArray</summary>
 <param name="p">Player to add to the smallest group.</param>
 <param name="Group:gs[]">An array of possible groups.</param>
 <param name="c">The number of USED items in the array.</param>
@@ -774,16 +772,22 @@ remotefunc void:_Group_SetPlayer(p, Bit:g[sizeof RG@], s)
 	The group they have been added to.
 </returns>
 <remarks>
+	Puts a player in whichever of the given groups currently has the least
+	players.
+	
+	Now ONLY takes a list - arrays should use "Group_SetBalancedArray".  As a
+	result, has more error-checking.
+	
 	Chains the call with "Group_SetPlayer" to use its hierarchy code.
 </remarks>
 \**--------------------------------------------------------------------------**/
 
-foreign Group:Group_SetBalancedInternal(p,Group:gs[],c);
+foreign Group:Group_SetBalancedArray(p,Group:gs[],c);
 
-global Group:Group_SetBalancedInternal(p,Group:gs[],c)
+global Group:Group_SetBalancedArray(p,Group:gs[],c)
 {
+	if (!(0 <= p < MAX_PLAYERS)) return INVALID_GROUP;
 	// Find which of the listed groups has the least players in.
-	//#pragma unused s
 	new
 		count = cellmax,
 		Group:id = INVALID_GROUP;
@@ -794,82 +798,66 @@ global Group:Group_SetBalancedInternal(p,Group:gs[],c)
 			gi = _:gs[i];
 		if (_Group_IsValid(Group:gi))
 		{
-			//GROUP_FIX(gi);
 			new
-				cc = Iter_Count(GroupPlayers[_:GROUP_TEMP_FIX(Group:gi)]);
-			if (_Group_HasPlayer(GROUP_TEMP_FIX(Group:gi),p))
+				g2 = _:GROUP_TEMP_FIX(Group:gi),
+				cc = Iter_Count(GroupPlayers[g2]);
+			if (_Group_HasPlayer(g2, p))
 			{
 				// The player is already in this group - prefer it to others.
-				--cc;
+				if (cc - 1 <= count)
+				{
+					count = cc - 1,
+					id = Group:gi;
+				}
 			}
-			if (cc < count)
+			else if (cc < count)
 			{
-				count = cc;
+				count = cc,
 				id = Group:gi;
 			}
 		}
 	}
-	Group_SetPlayer(id, p, true);
+	if (id == INVALID_GROUP)
+	{
+		P:W("Group_SetBalanced(Array) requires at least 1 valid group.");
+	}
+	else
+	{
+		Group_SetPlayer(id, p, true);
+	}
 	return id;
 }
 
 /**--------------------------------------------------------------------------**\
 <summary>Group_SetBalanced</summary>
 <param name="playerid">Player to put in one of a number of groups</param>
-<param name="{Group, _}:...">Either an array size then array, or a list of groups.</param>
+<param name="Group:...">A list of groups.</param>
 <returns>
 	-
 </returns>
 <remarks>
 	Puts a player in whichever of the given groups currently has the least
 	players.
+	
+	Now ONLY takes a list - arrays should use "Group_SetBalancedArray".  As a
+	result, has more error-checking.
 </remarks>
 \**--------------------------------------------------------------------------**/
 
-stock Group:Group_SetBalanced(playerid, {Group, _}:...)
+stock Group:Group_SetBalanced(playerid, Group:g0, Group:g1, Group:...)
 {
-	if (!(0 <= playerid < MAX_PLAYERS)) return INVALID_GROUP;
 	new
 		Group:possible[_MAX_GROUPS_G],
-		count = numargs();
-	switch (count)
+		count = min(_MAX_GROUPS_G + 1, numargs()),
+		i = 2,
+		j = 3;
+	possible[0] = g0,
+	possible[1] = g1;
+	while (j != count)
 	{
-		case 1, 2:
-		{
-			P:W("Group_SetBalanced requires at least 2 groups or an array.");
-		}
-		case 3:
-		{
-			new
-				third = getarg(2);
-			if (third & _:GROUP_MASK)
-			{
-				// Two groups.
-				possible[0] = Group:getarg(1);
-				possible[1] = Group:third;
-				return Group_SetBalancedInternal(playerid, possible, 2);
-			}
-			else
-			{
-				third = min(third, _MAX_GROUPS_G);
-				// Array of groups.
-				for (new i = 0; i != third; ++i)
-				{
-					possible[i] = Group:getarg(1, i);
-				}
-				return Group_SetBalancedInternal(playerid, possible, third);
-			}
-		}
-		default:
-		{
-			for (new i = 1; i != count; ++i)
-			{
-				possible[i - 1] = Group:getarg(i);
-			}
-			return Group_SetBalancedInternal(playerid, possible, count - 1);
-		}
+		possible[i++] = Group:getarg(j++);
 	}
-	return INVALID_GROUP;
+	return Group_SetBalancedArray(playerid, possible, i);
 }
 
 /**--------------------------------------------------------------------------**\

--- a/YSI_Players/y_groups/impl.inc
+++ b/YSI_Players/y_groups/impl.inc
@@ -803,12 +803,8 @@ global Group:Group_SetBalancedArray(p,Group:gs[],c)
 				cc = Iter_Count(GroupPlayers[g2]);
 			if (_Group_HasPlayer(g2, p))
 			{
-				// The player is already in this group - prefer it to others.
-				if (cc - 1 <= count)
-				{
-					count = cc - 1,
-					id = Group:gi;
-				}
+				// The player is already in this group - just return.
+				return gi;
 			}
 			else if (cc < count)
 			{

--- a/YSI_Players/y_groups/tests.inc
+++ b/YSI_Players/y_groups/tests.inc
@@ -329,8 +329,8 @@ Test:y_groups_SetBalancedIn2()
 
 	Group_SetBalancedArray(0, g, sizeof(g));
 
-	ASSERT(Group_GetCount(g[0]) == 2);
-	ASSERT(Group_GetCount(g[1]) == 1);
+	ASSERT(Group_GetCount(g[0]) == 3);
+	ASSERT(Group_GetCount(g[1]) == 0);
 	ASSERT(Group_GetCount(g[2]) == 3);
 
 	call OnPlayerDisconnect(0, 0);
@@ -372,8 +372,8 @@ Test:y_groups_SetBalancedIn3()
 	Group_SetBalancedArray(4, g, sizeof(g));
 
 	ASSERT(Group_GetCount(g[0]) == 3);
-	ASSERT(Group_GetCount(g[1]) == 1);
-	ASSERT(Group_GetCount(g[2]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 0);
+	ASSERT(Group_GetCount(g[2]) == 3);
 
 	call OnPlayerDisconnect(0, 0);
 	call OnPlayerDisconnect(1, 0);
@@ -547,8 +547,8 @@ Test:y_groups_SetBalancedIn4()
 	Group_SetBalancedArray(2, g, sizeof(g));
 
 	ASSERT(Group_GetCount(g[0]) == 2);
-	ASSERT(Group_GetCount(g[1]) == 2);
-	ASSERT(Group_GetCount(g[2]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 3);
+	ASSERT(Group_GetCount(g[2]) == 1);
 
 	call OnPlayerDisconnect(0, 0);
 	call OnPlayerDisconnect(1, 0);
@@ -570,7 +570,7 @@ Test:y_groups_SetBalancedSingle()
 		Group:result;
 	call OnPlayerConnect(0);
 	
-	result = Group_SetBalanced(0, g1);
+	result = Group_SetBalanced(0, g1, Group:11);
 	ASSERT(result == g1);
 	
 	call OnPlayerDisconnect(0, 0);
@@ -583,7 +583,7 @@ Test:y_groups_SetBalancedInvalid()
 		Group:result;
 	call OnPlayerConnect(0);
 	
-	result = Group_SetBalanced(0, Group:99);
+	result = Group_SetBalanced(0, Group:99, Group:88);
 	ASSERT(result == INVALID_GROUP);
 	
 	call OnPlayerDisconnect(0, 0);

--- a/YSI_Players/y_groups/tests.inc
+++ b/YSI_Players/y_groups/tests.inc
@@ -142,62 +142,80 @@ Test:y_groups_Set3()
 		Group:g = Group_Create("Group 8");
 	Group_SetPlayer(g, 42, true);
 	ASSERT(Group_GetCount(g) == 1);
-	//W@(#On#PlayerDisconnect         ,x:#ii#,42, 0);
 	call OnPlayerDisconnect(42, 0);
-	//ASSERT(Group_GetCount(g) == 0);
-	//call OnPlayerConnect(42);
-	//ASSERT(Group_GetCount(g) == 0);
 	Group_Destroy(g);
+}
+
+Test:y_groups_SetBalanced0()
+{
+	new
+		Group:g1 = Group_Create("Group 1"),
+		Group:g2 = Group_Create("Group 2");
+	
+	call OnPlayerConnect(22);
+	
+	Group_SetPlayer(g2, 22, true);
+	Group_SetBalanced(22, g1, g2);
+	
+	ASSERT(Group_GetCount(g1) == 0 && Group_GetCount(g2) == 1);
+	
+	call OnPlayerDisconnect(22, 0);
+	
+	Group_Destroy(g1);
+	Group_Destroy(g2);
 }
 
 Test:y_groups_SetBalanced1()
 {
-	new Group:g1 = Group_Create("Group 1"),Group:g2 = Group_Create("Group 2");
-
-	call OnPlayerConnect(23, 0);
-	call OnPlayerConnect(32, 0);
-
-	Group_SetBalanced(23,g1,g2);
-	Group_SetBalanced(32,g1,g2);
-
+	new
+		Group:g1 = Group_Create("Group 1"),
+		Group:g2 = Group_Create("Group 2");
+	
+	call OnPlayerConnect(23);
+	call OnPlayerConnect(32);
+	
+	Group_SetBalanced(23, g1, g2);
+	Group_SetBalanced(32, g1, g2);
+	
 	ASSERT(Group_GetCount(g1) == 1 && Group_GetCount(g2) == 1);
-
+	
 	call OnPlayerDisconnect(23, 0);
 	call OnPlayerDisconnect(32, 0);
-
+	
 	Group_Destroy(g1);
 	Group_Destroy(g2);
 }
 
 Test:y_groups_SetBalanced2()
 {
-	new Group:g1 = Group_Create("Group 1"),
+	new
+		Group:g1 = Group_Create("Group 1"),
 		Group:g2 = Group_Create("Group 2"),
 		Group:g3 = Group_Create("Group 3");
-
-	call OnPlayerConnect(1, 0);
-	call OnPlayerConnect(2, 0);
-	call OnPlayerConnect(3, 0);
-	call OnPlayerConnect(4, 0);
-	call OnPlayerConnect(5, 0);
-	call OnPlayerConnect(6, 0);
-
-	Group_SetBalanced(1,g1,g2,g3);
-	Group_SetBalanced(2,g1,g2,g3);
-	Group_SetBalanced(3,g1,g2,g3);
-	Group_SetBalanced(4,g1,g2,g3);
-	Group_SetBalanced(5,g1,g2,g3);
-	Group_SetBalanced(6,g1,g2,g3);
-
+	
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetBalanced(1, g1, g2, g3);
+	Group_SetBalanced(2, g1, g2, g3);
+	Group_SetBalanced(3, g1, g2, g3);
+	Group_SetBalanced(4, g1, g2, g3);
+	Group_SetBalanced(5, g1, g2, g3);
+	Group_SetBalanced(6, g1, g2, g3);
+	
 	ASSERT(Group_GetCount(g1) == 2 && Group_GetCount(g2) == 2 && Group_GetCount(g3) == 2);
-
+	
 	call OnPlayerDisconnect(1, 0);
 	call OnPlayerDisconnect(2, 0);
 	call OnPlayerDisconnect(3, 0);
 	call OnPlayerDisconnect(4, 0);
 	call OnPlayerDisconnect(5, 0);
 	call OnPlayerDisconnect(6, 0);
-
+	
 	Group_Destroy(g1);
 	Group_Destroy(g2);
 	Group_Destroy(g3);
@@ -205,7 +223,8 @@ Test:y_groups_SetBalanced2()
 
 Test:y_groups_SetBalanced3()
 {
-	new Group:g[3];
+	new
+		Group:g[3];
 	g[0] = Group_Create("Group 1");
 	g[1] = Group_Create("Group 2");
 	g[2] = Group_Create("Group 3");
@@ -218,13 +237,13 @@ Test:y_groups_SetBalanced3()
 	call OnPlayerConnect(5);
 	call OnPlayerConnect(6);
 
-	Group_SetBalanced(0,g,sizeof(g));
-	Group_SetBalanced(1,g,sizeof(g));
-	Group_SetBalanced(2,g,sizeof(g));
-	Group_SetBalanced(3,g,sizeof(g));
-	Group_SetBalanced(4,g,sizeof(g));
-	Group_SetBalanced(5,g,sizeof(g));
-	Group_SetBalanced(6,g,sizeof(g));
+	Group_SetBalancedArray(0, g, sizeof(g));
+	Group_SetBalancedArray(1, g, sizeof(g));
+	Group_SetBalancedArray(2, g, sizeof(g));
+	Group_SetBalancedArray(3, g, sizeof(g));
+	Group_SetBalancedArray(4, g, sizeof(g));
+	Group_SetBalancedArray(5, g, sizeof(g));
+	Group_SetBalancedArray(6, g, sizeof(g));
 
 	ASSERT(Group_GetCount(g[0]) == 3);
 	ASSERT(Group_GetCount(g[1]) == 2);
@@ -243,16 +262,331 @@ Test:y_groups_SetBalanced3()
 	Group_Destroy(g[2]);
 }
 
-Test:y_groups_SetBalancedInvalid()
+Test:y_groups_SetBalancedIn1()
 {
-	new Group:g1 = Group_Create("Group 1"),Group:result;
-	call OnPlayerConnect(0, 0);
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
 
-	result = Group_SetBalanced(0,g1);
-	ASSERT(result == INVALID_GROUP);
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[0], 2, true);
+	Group_SetPlayer(g[2], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+
+	Group_SetBalancedArray(6, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 3);
+	ASSERT(Group_GetCount(g[1]) == 1);
+	ASSERT(Group_GetCount(g[2]) == 3);
 
 	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn2()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[0], 2, true);
+	Group_SetPlayer(g[2], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+
+	Group_SetBalancedArray(0, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 1);
+	ASSERT(Group_GetCount(g[2]) == 3);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn3()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[0], 2, true);
+	Group_SetPlayer(g[2], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+
+	Group_SetBalancedArray(4, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 3);
+	ASSERT(Group_GetCount(g[1]) == 1);
+	ASSERT(Group_GetCount(g[2]) == 2);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn3a()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[1], 2, true);
+	Group_SetPlayer(g[1], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+	
+	Group_SetPlayer(g[0], 6, true);
+
+	Group_SetBalancedArray(0, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 3);
+	ASSERT(Group_GetCount(g[1]) == 2);
+	ASSERT(Group_GetCount(g[2]) == 2);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn3b()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[1], 2, true);
+	Group_SetPlayer(g[1], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+	
+	Group_SetPlayer(g[1], 6, true);
+
+	Group_SetBalancedArray(0, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 3);
+	ASSERT(Group_GetCount(g[2]) == 2);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn3c()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[1], 2, true);
+	Group_SetPlayer(g[1], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	Group_SetPlayer(g[2], 5, true);
+	
+	Group_SetPlayer(g[2], 6, true);
+
+	Group_SetBalancedArray(0, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 2);
+	ASSERT(Group_GetCount(g[2]) == 3);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedIn4()
+{
+	new
+		Group:g[3];
+	g[0] = Group_Create("Group 1");
+	g[1] = Group_Create("Group 2");
+	g[2] = Group_Create("Group 3");
+
+	call OnPlayerConnect(0);
+	call OnPlayerConnect(1);
+	call OnPlayerConnect(2);
+	call OnPlayerConnect(3);
+	call OnPlayerConnect(4);
+	call OnPlayerConnect(5);
+	call OnPlayerConnect(6);
+	
+	Group_SetPlayer(g[0], 0, true);
+	Group_SetPlayer(g[0], 1, true);
+	Group_SetPlayer(g[1], 2, true);
+	Group_SetPlayer(g[1], 3, true);
+	Group_SetPlayer(g[2], 4, true);
+	
+	Group_SetPlayer(g[1], 6, true);
+
+	Group_SetBalancedArray(2, g, sizeof(g));
+
+	ASSERT(Group_GetCount(g[0]) == 2);
+	ASSERT(Group_GetCount(g[1]) == 2);
+	ASSERT(Group_GetCount(g[2]) == 2);
+
+	call OnPlayerDisconnect(0, 0);
+	call OnPlayerDisconnect(1, 0);
+	call OnPlayerDisconnect(2, 0);
+	call OnPlayerDisconnect(3, 0);
+	call OnPlayerDisconnect(4, 0);
+	call OnPlayerDisconnect(5, 0);
+	call OnPlayerDisconnect(6, 0);
+
+	Group_Destroy(g[0]);
+	Group_Destroy(g[1]);
+	Group_Destroy(g[2]);
+}
+
+Test:y_groups_SetBalancedSingle()
+{
+	new
+		Group:g1 = Group_Create("Group 1"),
+		Group:result;
+	call OnPlayerConnect(0);
+	
+	result = Group_SetBalanced(0, g1);
+	ASSERT(result == g1);
+	
+	call OnPlayerDisconnect(0, 0);
 	Group_Destroy(g1);
+}
+
+Test:y_groups_SetBalancedInvalid()
+{
+	new
+		Group:result;
+	call OnPlayerConnect(0);
+	
+	result = Group_SetBalanced(0, Group:99);
+	ASSERT(result == INVALID_GROUP);
+	
+	call OnPlayerDisconnect(0, 0);
 }
 
 #define MASTER 60

--- a/YSI_Storage/y_amx.inc
+++ b/YSI_Storage/y_amx.inc
@@ -74,9 +74,7 @@ Changelog:
 #include "..\YSI_Core\y_debug"
 #include "..\YSI_Internal\y_natives"
 
-#include "..\amx\asm"
-#include "..\amx\disasm"
-#include "..\amx\frame_info"
+#include "..\YSI_Internal\amx_assembly"
 
 #define AMX_FastString(%1,%2,%3,%4) \
 	(((%1) << 0) | ((%2) << 8) | ((%3) << 16) | ((%4) << 24))

--- a/YSI_Storage/y_ini.inc
+++ b/YSI_Storage/y_ini.inc
@@ -203,7 +203,7 @@ stock const
 
 #define INI_NO_FILE (INI:-1)
 
-#include "..\amx\os"
+#include "..\YSI_Internal\amx_assembly"
 #include "..\YSI_Internal\y_version"
 
 #include "..\YSI_Core\y_utils"

--- a/YSI_Storage/y_xml.inc
+++ b/YSI_Storage/y_xml.inc
@@ -224,11 +224,13 @@ stock XML_Parse(XML:rule, filename[])
 			inClose,
 			inOpen,
 			inComment,
+			lineOffset,
 			value[MAX_XML_ENTRY_TEXT],
 			name[MAX_XML_ENTRY_NAME],
 			inPar;
-		while (fread(xFile, line))
+		while (fread(xFile, line[lineOffset], sizeof (line) - lineOffset))
 		{
+			lineOffset = 0;
 			P:5("XML_Parse() line: %s", line);
 			new
 				pos,
@@ -247,16 +249,31 @@ stock XML_Parse(XML:rule, filename[])
 					inComment = 0;
 				}
 			}
-			while ((ch = line[pos]) && ch <= ' ') pos++;
-			while (ch)
+			for ( ; ; ) switch ((ch = line[pos]))
 			{
-				if (ch <= ' ') pos++;
-				else if (ch == '<')
+				case '\0':
 				{
-					pos++;
+					break;
+				}
+				case '\1' .. ' ':
+				{
+					if (pos > (YSI_MAX_STRING * 2 / 3))
+					{
+						// 2/3 of the way through the line and found a space -
+						// use this as a handy break point for long lines.
+						++pos;
+						lineOffset = sizeof (line) - 1 - pos;
+						memcpy(line, line[pos], 0, lineOffset * cellbytes);
+						break;
+					}
+					++pos;
+				}
+				case '<':
+				{
+					++pos;
 					if (line[pos] == '/')
 					{
-						pos++;
+						++pos;
 						tagCount--;
 						if (gotLastValue)
 						{
@@ -291,23 +308,23 @@ stock XML_Parse(XML:rule, filename[])
 					{
 						inOpen = 1;
 						tagCount++;
-						while ((ch = line[pos]) && XML_IsChar(ch)) pos++;
+						while ((ch = line[pos]) && XML_IsChar(ch)) ++pos;
 						//name = XML_GetName(line, pos);
 					}
 					gotLastValue = 0;
 					inPar = 0;
 				}
-				else if (ch == '>')
+				case '>':
 				{
 					inPar = inClose ? 0 : 1;
 					inOpen = 0;
 					inClose = 0;
-					pos++;
+					++pos;
 				}
-				else if (ch == '/')
+				case '/':
 				{
 					// Self-closing tags (FINALLY)!
-					pos++;
+					++pos;
 					if (inOpen)
 					{
 						tagCount--;
@@ -325,22 +342,24 @@ stock XML_Parse(XML:rule, filename[])
 						inClose = 1; // Well, we sort of are...
 					}
 				}
-				else if (inPar)
+				default:
 				{
-					value = XML_GetValue(line, pos);
-					gotLastValue = 1;
+					if (inPar)
+					{
+						value = XML_GetValue(line, pos);
+						gotLastValue = 1;
+					}
+					else if (inOpen)
+					{
+						name = XML_GetName(line, pos);
+						value = XML_GetParameter(line, pos);
+						XML_Push(name, value, tagCount);
+					}
+					else
+					{
+						++pos;
+					}
 				}
-				else if (inOpen)
-				{
-					name = XML_GetName(line, pos);
-					value = XML_GetParameter(line, pos);
-					XML_Push(name, value, tagCount);
-				}
-				else
-				{
-					pos++;
-				}
-				ch = line[pos];
 			}
 		}
 		fclose(xFile);
@@ -482,7 +501,7 @@ stock XML_GetValue(line[], &pos)
 	pos--;
 	if (i == (sizeof (ret) - 1))
 	{
-		while (((ch = line[pos]) >= ' ' || ch == '\t') && (ch != '<')) pos++;
+		while (((ch = line[pos]) >= ' ' || ch == '\t') && (ch != '<')) ++pos;
 	}
 	ret[i] = '\0';
 	return ret;
@@ -511,7 +530,7 @@ stock XML_GetName(line[], &pos)
 	pos--;
 	if (i == (sizeof (ret) - 1))
 	{
-		while ((ch = line[pos]) >= ' ' && XML_IsChar(ch)) pos++;
+		while ((ch = line[pos]) >= ' ' && XML_IsChar(ch)) ++pos;
 	}
 	ret[i] = '\0';
 	return ret;
@@ -1045,15 +1064,15 @@ stock XML_ReplaceItem(file[], tag[], name[], replacement)
 				new
 					pos,
 					ch;
-				while ((ch = line[pos]) && ch <= ' ') pos++;
+				while ((ch = line[pos]) && ch <= ' ') ++pos;
 				while (ch)
 				{
-					if (ch <= ' ') pos++;
+					if (ch <= ' ') ++pos;
 					else if (ch == '<')
 					{
 						if (line[++pos] == '/')
 						{
-							pos++;
+							++pos;
 							tagCount--;
 							if (inTag && tagCount <= atStart) inTag = 3;
 						}
@@ -1064,13 +1083,13 @@ stock XML_ReplaceItem(file[], tag[], name[], replacement)
 							{
 								if (!strcmp(XML_GetName(line, pos), tag)) inTag = 1;
 							}
-							else while ((ch = line[pos]) && XML_IsChar(ch)) pos++;
+							else while ((ch = line[pos]) && XML_IsChar(ch)) ++pos;
 						}
 					}
 					else if (ch == '>')
 					{
 						if (inTag == 1) inTag = 0;
-						pos++;
+						++pos;
 					}
 					else if (inTag == 1)
 					{
@@ -1089,7 +1108,8 @@ stock XML_ReplaceItem(file[], tag[], name[], replacement)
 						}
 						else XML_GetParameter(line, pos);
 					}
-					else pos++;
+					else
+						++pos;
 					ch = line[pos];
 				}
 				if (!inTag) fwrite(__ftemp, line);

--- a/YSI_Storage/y_xml.inc
+++ b/YSI_Storage/y_xml.inc
@@ -225,22 +225,29 @@ stock XML_Parse(XML:rule, filename[])
 			inOpen,
 			inComment,
 			lineOffset,
+			lineLen,
 			value[MAX_XML_ENTRY_TEXT],
 			name[MAX_XML_ENTRY_NAME],
 			inPar;
-		while (fread(xFile, line[lineOffset], sizeof (line) - lineOffset))
+		while ((lineLen = fread(xFile, line[lineOffset], sizeof (line) - lineOffset)))
 		{
-			lineOffset = 0;
 			P:5("XML_Parse() line: %s", line);
 			new
 				pos,
 				ch;
+			lineOffset = 0;
 			if (inComment)
 			{
 				pos = strfind(line, "-->", false, 0);
 				if (pos == -1)
 				{
 					// Skip this whole line.
+					if (lineLen == YSI_MAX_STRING - 1)
+					{
+						// Check that "-->" doesn't span two read-in blocks.
+						memcpy(line, line[sizeof (line) - 3], 0, 3 * cellbytes);
+						lineOffset = 2;
+					}
 					continue;
 				}
 				else
@@ -257,7 +264,7 @@ stock XML_Parse(XML:rule, filename[])
 				}
 				case '\1' .. ' ':
 				{
-					if (pos > (YSI_MAX_STRING * 2 / 3))
+					if (lineLen == YSI_MAX_STRING - 1 && pos > (YSI_MAX_STRING * 2 / 3))
 					{
 						// 2/3 of the way through the line and found a space -
 						// use this as a handy break point for long lines.
@@ -292,11 +299,20 @@ stock XML_Parse(XML:rule, filename[])
 					}
 					else if (line[pos] == '!' && line[pos + 1] == '-' && line[pos + 2] == '-')
 					{
-						// XML comments.
+						// XML comments.  XML doesn't support nested comments.
+						// I am a firm believer that they are the future, but
+						// this code isn't clever enough to parse them (being
+						// very old), and since they aren't supported there is
+						// no need to add them.
 						pos = strfind(line, "-->", false, pos + 3);
 						if (pos == -1)
 						{
 							inComment = 1;
+							if (lineLen == YSI_MAX_STRING - 1)
+							{
+								memcpy(line, line[sizeof (line) - 3], 0, 3 * cellbytes);
+								lineOffset = 2;
+							}
 							break;
 						}
 						else


### PR DESCRIPTION
1. Changed the semantics of `Group_SetBalanced`.  If the player is already in a group, return that group instead of continuing.  This is because removing a player from a group is tricky if that group contains other groups - should they be removed from those other groups as well?  And what if they were added to those child groups independently, should they STILL be removed from that group when removed from the parent group?  The simplest solution is to let the user remove players from any existing groups first, so that they know the correct removal semantics to use, THEN call `Group_SetBalanced`.  This also changes the function to no longer take either a list OR an array, JUST a list, and adds `Group_SetBalancedArray` to make up the difference.  Finally, the validity of groups has been moved, and more validation and flexibility added.  Previously, if there was more than one group given that was considered fine, even if some were not valid groups.  Now there must be at least one valid group given, but now one group is fine - just add them to that one.
2. Added two new iterator functions:

``` pawn
new
    Iterator:iter<4, 10>
Iter_Add(iter<0>, 2);
Iter_Add(iter<0>, 3);
Iter_Add(iter<1>, 5);
Iter_Add(iter<2>, 6);
Iter_Add(iter<2>, 7);
Iter_Add(iter<3>, 9);

// Loops over all values in ANY part of the multi-iterator.
foreach (new i : All(iter<>))
{
    printf("%d", i);
}

// Output:
//   
//   2
//   3
//   5
//   6
//   7
//   9
//   

// Loops over values not in ANY part of the multi-iterator.
foreach (new i : None(iter<>))
{
    printf("%d", i);
}

// Output:
//   
//   0
//   1
//   4
//   8
//   
```
1. Cleaned up y_malloc, and added `YSI_NO_HEAP_MALLOC` to use the old style y_malloc with a huge array instead of the heap.  This MAY fix #62, #91 , #99, and Southclaw/ScavengeSurvive#248.
2. General fixes for #97 and #98.
3. Changed how Zeex/amx_assembly is included.  All the inclusions are now in one file, and the repository location is VERY forgiving.
4. Added local state so certain special iterators.  This is now possible:

``` pawn
foreach (new i : Random(10, 0, 100)) // count, min, max.
{
    foreach (new i : Random(10, 0, 100)) // count, min, max.
    {
    }
}
```

Previously, `Random` and a few other iterators used static variables within themselves to keep track of extra data, meaning that they couldn't be nested.  Now that extra data is declared hidden within the `foreach` loop.
1. Improved y_testing - better support for run-time errors, and lists the names of tests that failed in the summary instead of making you search through all the tests for the ones that failed.
