### PR TITLE
Remove warning when including YSI\y_iterate twice

### DIFF
--- a/YSI_Data/y_iterate.inc
+++ b/YSI_Data/y_iterate.inc
@@ -226,6 +226,7 @@ Iterators:
 
 // Foreach is testing us.
 #if defined _FOREACH_INC_TEST
+	#undef _FOREACH_CUR_VERSION
 	#define _FOREACH_CUR_VERSION _Y_ITERATE_LOCAL_VERSION
 	#endinput
 #endif


### PR DESCRIPTION
When including YSI\y_iterate twice or more in the script, the warning:  popped up:
``\YSI_Data\y_iterate.inc(229) : warning 201: redefinition of constant/macro (symbol "_FOREACH_CUR_VERSION")``