### PR TITLE
Update styles.inc

### DIFF
--- a/YSI_Players/y_text/styles.inc
+++ b/YSI_Players/y_text/styles.inc
@@ -227,8 +227,8 @@ public Styles_EntryTag()
 			{
 				// Better "strval" for short numbers.
 				new
-					tmp = val[0] - '0';
-				if (0 <= tmp <= 6)
+					tmp = (val[0] - '0') + 1;
+				if (1 <= tmp <= 7)
 				{
 					type = e_STYLE_TYPE_GT_0 * e_STYLE_TYPE:tmp;
 				}


### PR DESCRIPTION
Fixes issue #147 

I've been researching about this bug and seems it's caused mainly by the enum's modifier (`e_STYLE_TYPE`). I didn't change it just in case of anything else gets bugged but I added a little fix in order to make this work correctly.

Users can use [game text styles](http://wiki.sa-mp.com/wiki/GameTextStyle) normally now. 