### PR TITLE
Increase dialog buttons characters

### DIFF
--- a/YSI_Players/y_text/impl.inc
+++ b/YSI_Players/y_text/impl.inc
@@ -1832,8 +1832,8 @@ stock _Text_Render(playerid, search[], ident[], GLOBAL_TAG_TYPES:...)
 
 static stock
 	YSI_g_sCaptionText[YSI_MAX_LANGUAGES][64],
-	YSI_g_sButton1Text[YSI_MAX_LANGUAGES][16],
-	YSI_g_sButton2Text[YSI_MAX_LANGUAGES][16];
+	YSI_g_sButton1Text[YSI_MAX_LANGUAGES][24],
+	YSI_g_sButton2Text[YSI_MAX_LANGUAGES][24];
 
 /*-------------------------------------------------------------------------*//**
  *//*------------------------------------------------------------------------**/

--- a/YSI_Players/y_text/impl.inc
+++ b/YSI_Players/y_text/impl.inc
@@ -1832,8 +1832,8 @@ stock _Text_Render(playerid, search[], ident[], GLOBAL_TAG_TYPES:...)
 
 static stock
 	YSI_g_sCaptionText[YSI_MAX_LANGUAGES][64],
-	YSI_g_sButton1Text[YSI_MAX_LANGUAGES][24],
-	YSI_g_sButton2Text[YSI_MAX_LANGUAGES][24];
+	YSI_g_sButton1Text[YSI_MAX_LANGUAGES][16],
+	YSI_g_sButton2Text[YSI_MAX_LANGUAGES][16];
 
 /*-------------------------------------------------------------------------*//**
  *//*------------------------------------------------------------------------**/

--- a/YSI_Storage/y_ini/reading.inc
+++ b/YSI_Storage/y_ini/reading.inc
@@ -443,6 +443,8 @@ stock e_INI_LINE_TYPE:
 		case '=': return e_INI_LINE_TYPE_INVALID;
 		default: p0s = pos - 1;
 	}
+	// Default end point, for single-character lines.
+	end = pos;
 //state_in_entry: // Default (fall-through).
 	// Get the key.
 	for ( ; ; )

--- a/YSI_Visual/y_commands/impl.inc
+++ b/YSI_Visual/y_commands/impl.inc
@@ -457,6 +457,8 @@ global Command_ReProcess(p,string:c[],h)
 	#if !defined Y_COMMANDS_NO_IPC
 		if (!IsPlayerConnected(p)) return Command_OnReceived(NO_PLAYER, p, c);
 	#endif
+	new
+		prevID = YSI_g_sCurrentID;
 	if (PA_Get(YSI_g_sDisabledPlayers, p))
 	{
 		sRet = Command_OnReceived(DISABLED, p, c);
@@ -468,8 +470,6 @@ global Command_ReProcess(p,string:c[],h)
 		}
 	}
 	P:1("Commands_OnPlayerCommandText called: %d %s", p, c);
-	new
-		prevID = YSI_g_sCurrentID;
 	// Get the hashed version of the decoded string, skipping the possible  "/".
 	sPos = Puny_EncodeHash(sCmd[4], c[sRet], sHash, .delimiter = '@') + sRet;
 	while (c[sPos] == ' ') ++sPos; // Better/slower: ('\0' < c[sPos] <= ' ').


### PR DESCRIPTION
Only 11 or 12 characters are displayed correctly on dialog buttons, I increased the array size for color embedding. As a curiosity, buttons support more than 128 characters.

Now something like `{FFFFFF}Got {FF0000}It` displays correctly. On the other hand, if someone uses the next code, theoretically it's correct but YSI would shorten it (usually people use simple buttons):
`{ff0000}q{00ff00}w{0000ff}e{ffffff}r{ff0000}t{00ff00}y{0000ff}u{ffffff}i{ff0000}o{00ff00}p{0000ff}a{ffffff}s`

Keep in mind that fading wouldn't work at all on dialog buttons making use of 24 cells only.