### PR TITLE
Add MySQL ORM functions for y_inline

### DIFF
--- a/YSI_Coding/y_inline/y_inline_extra.inc
+++ b/YSI_Coding/y_inline/y_inline_extra.inc
@@ -84,37 +84,37 @@ stock MySQL_TQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPE
 	mysql_tquery(handle, YSI_UNSAFE_HUGE_STRING, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Select_Inline(ORM:id, Func:cb<>)
+stock ORM_SelectInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_select(id, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Update_Inline(ORM:id, Func:cb<>)
+stock ORM_UpdateInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_update(id, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Insert_Inline(ORM:id, Func:cb<>)
+stock ORM_InsertInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_insert(id, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Delete_Inline(ORM:id, Func:cb<>)
+stock ORM_DeleteInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_delete(id, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Load_Inline(ORM:id, Func:cb<>)
+stock ORM_LoadInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_load(id, "Inline_FromCallback", "ii", _:cb, true);
 }
 
-stock ORM_Save_Inline(ORM:id, Func:cb<>)
+stock ORM_SaveInline(ORM:id, Func:cb<>)
 {
 	Indirect_Claim(cb);
 	orm_save(id, "Inline_FromCallback", "ii", _:cb, true);

--- a/YSI_Coding/y_inline/y_inline_extra.inc
+++ b/YSI_Coding/y_inline/y_inline_extra.inc
@@ -84,6 +84,42 @@ stock MySQL_TQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPE
 	mysql_tquery(handle, YSI_UNSAFE_HUGE_STRING, "Inline_FromCallback", "ii", _:cb, true);
 }
 
+stock ORM_Select_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_select(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
+stock ORM_Update_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_update(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
+stock ORM_Insert_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_insert(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
+stock ORM_Delete_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_delete(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
+stock ORM_Load_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_load(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
+stock ORM_Save_Inline(ORM:id, Func:cb<>)
+{
+	Indirect_Claim(cb);
+	orm_save(id, "Inline_FromCallback", "ii", _:cb, true);
+}
+
 stock BCrypt_CheckInline(text[], hash[], Func:cb<>)
 {
 	Indirect_Claim(cb);


### PR DESCRIPTION
Since I noticed basic MySQL query functions were given an inline counterpart I though that the ORM ones may have one as well.