### PR TITLE
Return false when Sparse_TryGet fails

### DIFF
--- a/YSI_Data/y_sparsearray/y_sparsearray_entry.inc
+++ b/YSI_Data/y_sparsearray/y_sparsearray_entry.inc
@@ -126,7 +126,7 @@ stock Sparse_TryGet(const name[], index, &dest)
 		dest = SparseArray_DoRead(id, name, index);
 		return true;
 	}
-	return true;
+	return false;
 }
 
 /*-------------------------------------------------------------------------*//**


### PR DESCRIPTION
Both returns are currently returning true. It should return wether if the value is not found (false) according to the documentation.