### PR TITLE
Error handling on y_inline_extra

### DIFF
--- a/YSI_Coding/y_inline/y_inline_extra.inc
+++ b/YSI_Coding/y_inline/y_inline_extra.inc
@@ -73,10 +73,10 @@ Optional plugins:
 stock MySQL_PQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPES:...)
 {
 	new ret = mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
-	if(ret)
+	if (ret)
 	{
 		ret = mysql_pquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
-		if(ret)
+		if (ret)
 		{
 			Indirect_Claim(cb);
 		}
@@ -87,10 +87,10 @@ stock MySQL_PQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPE
 stock MySQL_TQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPES:...)
 {
 	new ret = mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
-	if(ret)
+	if (ret)
 	{
 		ret = mysql_tquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
-		if(ret)
+		if (ret)
 		{
 			Indirect_Claim(cb);
 		}
@@ -101,7 +101,7 @@ stock MySQL_TQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPE
 stock ORM_SelectInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_select(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -111,7 +111,7 @@ stock ORM_SelectInline(ORM:id, Func:cb<>)
 stock ORM_UpdateInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_update(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -121,7 +121,7 @@ stock ORM_UpdateInline(ORM:id, Func:cb<>)
 stock ORM_InsertInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_insert(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -131,7 +131,7 @@ stock ORM_InsertInline(ORM:id, Func:cb<>)
 stock ORM_DeleteInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_delete(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -141,7 +141,7 @@ stock ORM_DeleteInline(ORM:id, Func:cb<>)
 stock ORM_LoadInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_load(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -151,7 +151,7 @@ stock ORM_LoadInline(ORM:id, Func:cb<>)
 stock ORM_SaveInline(ORM:id, Func:cb<>)
 {
 	new ret = orm_save(id, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -161,7 +161,7 @@ stock ORM_SaveInline(ORM:id, Func:cb<>)
 stock BCrypt_CheckInline(text[], hash[], Func:cb<>)
 {
 	new ret = bcrypt_check(text, hash, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}
@@ -171,7 +171,7 @@ stock BCrypt_CheckInline(text[], hash[], Func:cb<>)
 stock BCrypt_HashInline(text[], cost, Func:cb<>)
 {
 	new ret = bcrypt_hash(text, cost, "Indirect_FromCallback", "ii", _:cb, true);
-	if(ret)
+	if (ret)
 	{
 		Indirect_Claim(cb);
 	}

--- a/YSI_Coding/y_inline/y_inline_extra.inc
+++ b/YSI_Coding/y_inline/y_inline_extra.inc
@@ -72,63 +72,109 @@ Optional plugins:
 
 stock MySQL_PQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPES:...)
 {
-	Indirect_Claim(cb);
-	mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
-	mysql_pquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
+	if(ret)
+	{
+		ret = mysql_pquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
+		if(ret)
+		{
+			Indirect_Claim(cb);
+		}
+	}
+	return ret;
 }
 
 stock MySQL_TQueryInline(MySQL:handle, Func:cb<>, const query[], GLOBAL_TAG_TYPES:...)
 {
-	Indirect_Claim(cb);
-	mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
-	mysql_tquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = mysql_format(handle, YSI_UNSAFE_HUGE_STRING, YSI_UNSAFE_HUGE_LENGTH, query, ___(3));
+	if(ret)
+	{
+		ret = mysql_tquery(handle, YSI_UNSAFE_HUGE_STRING, "Indirect_FromCallback", "ii", _:cb, true);
+		if(ret)
+		{
+			Indirect_Claim(cb);
+		}
+	}
+	return ret;
 }
 
 stock ORM_SelectInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_select(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_select(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock ORM_UpdateInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_update(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_update(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock ORM_InsertInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_insert(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_insert(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock ORM_DeleteInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_delete(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_delete(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock ORM_LoadInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_load(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_load(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock ORM_SaveInline(ORM:id, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	orm_save(id, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = orm_save(id, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock BCrypt_CheckInline(text[], hash[], Func:cb<>)
 {
-	Indirect_Claim(cb);
-	bcrypt_check(text, hash, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = bcrypt_check(text, hash, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 
 stock BCrypt_HashInline(text[], cost, Func:cb<>)
 {
-	Indirect_Claim(cb);
-	bcrypt_hash(text, cost, "Indirect_FromCallback", "ii", _:cb, true);
+	new ret = bcrypt_hash(text, cost, "Indirect_FromCallback", "ii", _:cb, true);
+	if(ret)
+	{
+		Indirect_Claim(cb);
+	}
+	return ret;
 }
 


### PR DESCRIPTION
Check return values of the called natives, since they can fail for the following reasons:

On MySQL the natives can fail because of:
* Invalid handle passed
* Format too small for string (this one's very unlikely though)
* Format specifier count/variables passed count mismatch (for example `no value for specifier '%d' passed`)

I also did it with the bcrypt plugin natives. I checked both plugins to be sure that 0/false actually means failure and 1/true is success.