### PR TITLE
Fixed "unused" warning for _SetColourHash

### DIFF
--- a/YSI_Server/y_colours/y_colours_entry.inc
+++ b/YSI_Server/y_colours/y_colours_entry.inc
@@ -173,7 +173,7 @@ stock SetColourHash(hash, color)
 }
 
 #define SetColorHash SetColourHash
-remotefunc void:_SetColourHash(hash, color)
+remotefunc static stock void:_SetColourHash(hash, color)
 {
 	P:3("SetColourHash called: %i, %i", hash, color);
 	color &= 0xFFFFFF00;


### PR DESCRIPTION
Including y_colours without actually using it triggers a warning.

```(warning) symbol is never used: "_@_SetColourHash"```

I've added the keywords static and stock to the function.