### PR TITLE
Correction of names and number of parameters

### DIFF
--- a/YSI_Core/y_functional/impl.inc
+++ b/YSI_Core/y_functional/impl.inc
@@ -106,7 +106,7 @@ stock MapIdx(callback:cb, const arr[], dest[], al = sizeof (arr), dl = sizeof (d
 	}
 	return CB_REL();
 }
-#define MapIdx({%0}%1)%8; LAMBDA_ii<IdxMap>{%0}(%1)%8;
+#define MapIdx({%0}%1)%8; LAMBDA_ii<MapIdx>{%0}(%1)%8;
 
 stock MapIdx_(callback:cb, const arr[], len = sizeof (arr))
 {
@@ -117,7 +117,7 @@ stock MapIdx_(callback:cb, const arr[], len = sizeof (arr))
 	}
 	return CB_REL();
 }
-#define MapIdx_({%0}%1)%8; LAMBDA_ii<IdxMap_>{%0}(%1)%8;
+#define MapIdx_({%0}%1)%8; LAMBDA_ii<MapIdx_>{%0}(%1)%8;
 
 stock ZipWith(callback:cb, const l[], const r[], dest[], ls = sizeof (l), rs = sizeof (r), ds = sizeof (dest))
 {
@@ -172,7 +172,7 @@ stock ZipWithIdx(callback:cb, const l[], const r[], dest[], ls = sizeof (l), rs 
 	}
 	return CB_REL();
 }
-#define ZipWithIdx({%0}%1)%8; LAMBDA_ii<ZipWith>{%0}(%1)%8;
+#define ZipWithIdx({%0}%1)%8; LAMBDA_iii<ZipWithIdx>{%0}(%1)%8;
 
 stock ZipWithIdx_(callback:cb, const l[], const r[], ls = sizeof (l), rs = sizeof (r))
 {
@@ -183,7 +183,7 @@ stock ZipWithIdx_(callback:cb, const l[], const r[], ls = sizeof (l), rs = sizeo
 	}
 	return CB_REL();
 }
-#define ZipWithIdx_({%0}%1)%8; LAMBDA_ii<ZipWith_>{%0}(%1)%8;
+#define ZipWithIdx_({%0}%1)%8; LAMBDA_iii<ZipWithIdx_>{%0}(%1)%8;
 
 stock ZipWith3Idx(callback:cb, const l[], const m[], const r[], dest[], ls = sizeof (l), ms = sizeof (m), rs = sizeof (r), ds = sizeof (dest))
 {
@@ -194,7 +194,7 @@ stock ZipWith3Idx(callback:cb, const l[], const m[], const r[], dest[], ls = siz
 	}
 	return CB_REL();
 }
-#define ZipWith3Idx({%0}%1)%8; LAMBDA_iii<ZipWith3>{%0}(%1)%8;
+#define ZipWith3Idx({%0}%1)%8; LAMBDA_iiii<ZipWith3Idx>{%0}(%1)%8;
 
 stock ZipWith3Idx_(callback:cb, const l[], const m[], const r[], ls = sizeof (l), ms = sizeof (m), rs = sizeof (r))
 {
@@ -205,7 +205,7 @@ stock ZipWith3Idx_(callback:cb, const l[], const m[], const r[], ls = sizeof (l)
 	}
 	return CB_REL();
 }
-#define ZipWith3Idx_({%0}%1)%8; LAMBDA_iii<ZipWith3_>{%0}(%1)%8;
+#define ZipWith3Idx_({%0}%1)%8; LAMBDA_iiii<ZipWith3Idx_>{%0}(%1)%8;
 
 stock FoldLIdx(callback:cb, n, const arr[], len = sizeof (arr))
 {
@@ -220,7 +220,7 @@ stock FoldLIdx(callback:cb, n, const arr[], len = sizeof (arr))
 		CB_REL(),
 		cur;
 }
-#define FoldLIdx({%0}%1)%8; LAMBDA_ii<FoldL>{%0}(%1)%8;
+#define FoldLIdx({%0}%1)%8; LAMBDA_iii<FoldLIdx>{%0}(%1)%8;
 
 stock ScanLIdx(callback:cb, n, const arr[], dest[], al = sizeof (arr), dl = sizeof (dest))
 {
@@ -240,7 +240,7 @@ stock ScanLIdx(callback:cb, n, const arr[], dest[], al = sizeof (arr), dl = size
 		CB_REL(),
 		1;
 }
-#define ScanLIdx({%0}%1)%8; LAMBDA_ii<ScanL>{%0}(%1)%8;
+#define ScanLIdx({%0}%1)%8; LAMBDA_iii<ScanLIdx>{%0}(%1)%8;
 
 stock FoldRIdx(callback:cb, const arr[], n, len = sizeof (arr))
 {
@@ -249,13 +249,13 @@ stock FoldRIdx(callback:cb, const arr[], n, len = sizeof (arr))
 		cur = n;
 	while (len--)
 	{
-		cur = CB_CALL(i, arr[len], cur);
+		cur = CB_CALL(len, arr[len], cur);
 	}
 	return
 		CB_REL(),
 		cur;
 }
-#define FoldRIdx({%0}%1)%8; LAMBDA_ii<FoldR>{%0}(%1)%8;
+#define FoldRIdx({%0}%1)%8; LAMBDA_iii<FoldRIdx>{%0}(%1)%8;
 
 stock ScanRIdx(callback:cb, n, const arr[], dest[], al = sizeof (arr), dl = sizeof (dest))
 {
@@ -267,13 +267,13 @@ stock ScanRIdx(callback:cb, n, const arr[], dest[], al = sizeof (arr), dl = size
 	dest[len] = cur;
 	while (len--)
 	{
-		dest[len] = cur = CB_CALL(i, arr[len], cur);
+		dest[len] = cur = CB_CALL(len, arr[len], cur);
 	}
 	return
 		CB_REL(),
 		1;
 }
-#define ScanRIdx({%0}%1)%8; LAMBDA_ii<ScanR>{%0}(%1)%8;
+#define ScanRIdx({%0}%1)%8; LAMBDA_iii<ScanRIdx>{%0}(%1)%8;
 
 stock FoldL1Idx(callback:cb, const arr[], len = sizeof (arr))
 {
@@ -289,7 +289,7 @@ stock FoldL1Idx(callback:cb, const arr[], len = sizeof (arr))
 		CB_REL(),
 		cur;
 }
-#define FoldL1Idx({%0}%1)%8; LAMBDA_ii<FoldL1>{%0}(%1)%8;
+#define FoldL1Idx({%0}%1)%8; LAMBDA_iii<FoldL1Idx>{%0}(%1)%8;
 
 stock FoldR1Idx(callback:cb, const arr[], len = sizeof (arr))
 {
@@ -299,13 +299,13 @@ stock FoldR1Idx(callback:cb, const arr[], len = sizeof (arr))
 		cur = arr[--len];
 	while (len--)
 	{
-		cur = CB_CALL(i, arr[len], cur);
+		cur = CB_CALL(len, arr[len], cur);
 	}
 	return
 		CB_REL(),
 		cur;
 }
-#define FoldR1Idx({%0}%1)%8; LAMBDA_ii<FoldR1>{%0}(%1)%8;
+#define FoldR1Idx({%0}%1)%8; LAMBDA_iii<FoldR1Idx>{%0}(%1)%8;
 
 stock FoldL(callback:cb, n, const arr[], len = sizeof (arr))
 {
@@ -462,7 +462,7 @@ stock bool:AllIdx(callback:cb, const arr[], len = sizeof (arr))
 		CB_REL(),
 		true;
 }
-#define AllIdx({%0}%1)%8; LAMBDA_i<All>{%0}(%1)%8;
+#define AllIdx({%0}%1)%8; LAMBDA_ii<AllIdx>{%0}(%1)%8;
 
 stock bool:AnyIdx(callback:cb, const arr[], len = sizeof (arr))
 {
@@ -475,7 +475,7 @@ stock bool:AnyIdx(callback:cb, const arr[], len = sizeof (arr))
 		CB_REL(),
 		false;
 }
-#define AnyIdx({%0}%1)%8; LAMBDA_i<Any>{%0}(%1)%8;
+#define AnyIdx({%0}%1)%8; LAMBDA_ii<AnyIdx>{%0}(%1)%8;
 
 stock Reverse(const arr[], len = sizeof (arr))
 {


### PR DESCRIPTION
Previously, this was modified by Blezi, but it was only for version 5.X, this is for version 4.X, I also solved an error with the names of the variables in some loops.