### PR TITLE
Clear YSI_g_sPlayerCallback after release

### DIFF
--- a/YSI_Visual/y_dialog/y_dialog_impl.inc
+++ b/YSI_Visual/y_dialog/y_dialog_impl.inc
@@ -90,6 +90,7 @@ remotefunc void:Dialog_Set(playerid, dialogid)
 	if (YSI_g_sPlayerMaster[playerid])
 	{
 		Indirect_Release(YSI_g_sPlayerCallback[playerid]),
+		YSI_g_sPlayerCallback[playerid] = Func:0<iiiis>,
 		YSI_g_sPlayerMaster[playerid] = false;
 	}
 }


### PR DESCRIPTION
```
[debug] Server crashed while executen gamemode.amx
[debug] AMX Backtrace:
[debug] #0 00000046 in Indirect_Release_ (func=68320) at <unknown_file>:0
[debug] #1 00039654 in Dialog_Set (playerid=6, dialogid=-1) at [...]/YSI_Visual/y_dialog/y_dialog_impl.inc:85
```

I've found a numerous amount of crashes which seem to be trying to free invalid function pointers. It seems there's a set of combination of Dialog functions which can leave `YSI_g_sPlayerCallback` with an invalid pointer which would be then be tried to be freed by `Indirect_Release`. I suspect a combination of `Dialog_Hide` and the `_ShowPlayerDialog` hook, the latter one sets `YSI_g_sPlayerMaster` to true without actually assigning a valid function pointer, and this variable being true means Dialog_Set will try to free whatever `YSI_g_sPlayerCallback` contains.

This PR clears the function pointer to 0 so Indirect_Release doesn't do any actual freeing.