### PR TITLE
Fix broken y_commands (y_master fix?)

### DIFF
--- a/YSI_Core/y_master/y_master__impl.inc
+++ b/YSI_Core/y_master/y_master__impl.inc
@@ -294,7 +294,12 @@ stock
 	{
 		// Called if this script is ending.
 		P:3(#MAKE_YCM<YSIM_VERSION...> "() <> called");
-		return cellmin;
+		if (YSI_gModuleShutdown)
+		{
+			return cellmin;
+		}
+		
+		return cellmax;
 	}
 #elseif _YSIM_IS_CLOUD
 		forward MAKE_YCM<YSIM_VERSION...>();
@@ -303,10 +308,15 @@ stock
 		{
 			// Return here for local (current version) gets.
 			P:3(#MAKE_YCM<YSIM_VERSION...> "() <> called");
-			return cellmin;
-		}
-		
+			if (YSI_gModuleShutdown)
+			{
+				return cellmin;
+			}
+
 	#if defined YSIM_VERSION
+			return YSIM_VERSION;
+		}
+
 		public MAKE_YCM<YSIM_VERSION...>() <_YCM:y>
 		{
 			P:3(#MAKE_YCM<YSIM_VERSION...> "() <y> called");
@@ -335,8 +345,11 @@ stock
 		}
 
 		#undef YSIM_VERSION
+	#else
+			return 0;
+		}
 	#endif
-		
+
 		public MAKE_YCM<YSIM_VERSION...>() <_YCM:u>
 		{
 			if (YSI_gModuleShutdown)
@@ -860,4 +873,3 @@ public _YCM() <>
 	// Do nothing at all (just define states).
 	P:E("%d: " #_YCM "() <> called", Master_ID());
 }
-


### PR DESCRIPTION
Fix #403 
Revert y_master__implc.inc from https://github.com/pawn-lang/YSI-Includes/commit/004ca29acc7e272fc7ab5c9154c56ee99e75df3a to https://github.com/pawn-lang/YSI-Includes/commit/8932d0afeebe6782f1e7a148021c332f86266fd5 as it broke y_commands (always return Unknown command)