### PR TITLE
Fix y_percent entry path

### DIFF
--- a/YSI_Data/y_percent.inc
+++ b/YSI_Data/y_percent.inc
@@ -93,16 +93,16 @@ Optional plugins:
 	#tryinclude "y_percent\y_percent_entry"
 #endif
 #if !defined _INC_y_percent
-	#tryinclude "YSI_Coding\y_percent\y_percent_entry"
+	#tryinclude "YSI_Data\y_percent\y_percent_entry"
 #endif
 #if !defined _INC_y_percent
-	#tryinclude "YSI\YSI_Coding\y_percent\y_percent_entry"
+	#tryinclude "YSI\YSI_Data\y_percent\y_percent_entry"
 #endif
 #if !defined _INC_y_percent
-	#tryinclude <YSI_Coding\y_percent\y_percent_entry>
+	#tryinclude <YSI_Data\y_percent\y_percent_entry>
 #endif
 #if !defined _INC_y_percent
-	#tryinclude <YSI\YSI_Coding\y_percent\y_percent_entry>
+	#tryinclude <YSI\YSI_Data\y_percent\y_percent_entry>
 #endif
 #if !defined _INC_y_percent
 	#error Could not find y_percent


### PR DESCRIPTION
Fix #605 about trying to include y_percent entry from YSI_Coding while the file itself is in the YSI_Data.