### PR TITLE
Fix `y_vehicledata` seat array

### DIFF
--- a/YSI_Game/y_vehicledata/y_vehicledata_entry.inc
+++ b/YSI_Game/y_vehicledata/y_vehicledata_entry.inc
@@ -1047,6 +1047,7 @@ stock
 		},
 	YSI_gVehicleSeats[VIM:VIM_MODEL_COUNT] = 
 		{
+			0,
 			4, 
 			2, 
 			2, 
@@ -1258,7 +1259,8 @@ stock
 			1, 
 			4, 
 			1, 
-			1
+			1,
+			0
 		};
 /*-------------------------------------------------------------------------*//**
  * <param name="vehicleid">The vehicleid to get speed.</param>


### PR DESCRIPTION
The placeholder values were missing from the `YSI_gVehicleSeats` array, thus the return values from the functions were not correct.